### PR TITLE
azure-voyage: fix Docker build pipeline for docker-compose --profile full

### DIFF
--- a/azure-voyage/.dockerignore
+++ b/azure-voyage/.dockerignore
@@ -1,0 +1,9 @@
+**/node_modules
+**/.next
+**/dist
+**/.turbo
+.git
+.env
+.env.test
+docs
+*.md

--- a/azure-voyage/.env.example
+++ b/azure-voyage/.env.example
@@ -14,3 +14,7 @@ ANTHROPIC_API_KEY=
 # 服務埠
 API_PORT=3001
 NEXT_PUBLIC_API_URL=http://localhost:3001
+
+# CORS 允許來源（正式環境／遠端部署建議設成前端實際網域；註解掉／不設定則全開，
+# 本機開發用預設值即可——注意：若取消註解，務必填入實際網址，空字串會讓 CORS 全部擋下）
+# WEB_ORIGIN=https://your-domain.example

--- a/azure-voyage/.npmrc
+++ b/azure-voyage/.npmrc
@@ -1,0 +1,1 @@
+inject-workspace-packages=true

--- a/azure-voyage/README.md
+++ b/azure-voyage/README.md
@@ -42,6 +42,24 @@ pnpm dev                      # 同時啟動 api (:3001) 與 web (:3000)
 
 驗證指令：`pnpm lint`、`pnpm typecheck`、`pnpm test`、`pnpm build`。
 
+## 用 Docker 一鍵試玩（不動到本機環境）
+
+不想在本機裝 Node / pnpm / PostgreSQL / Redis，只想開個容器玩玩看的話：
+
+```bash
+cp .env.example .env          # 預設值就能玩；要開 AI 就在這裡填 ANTHROPIC_API_KEY 並把 AI_ENABLED 改 true
+docker compose --profile full up --build
+```
+
+等 `api` 印出 `listening on :3001`、`web` 印出 `Ready` 後，打開 http://localhost:3000 即可遊玩。
+Postgres／Redis 資料存在 Docker volume（`azure-voyage_pgdata` / `azure-voyage_redisdata`）裡，不會碰到本機任何東西；`docker compose --profile full down`（要連資料一起清掉再加 `-v`）即可完整移除，不留痕跡。
+
+想再切回本機開發模式（有熱重載），用預設不帶 `--profile full` 的 `docker compose up -d`（只起 postgres + redis）配合 `pnpm dev` 即可，兩種模式的資料庫連線資訊相同，不會互相干擾。
+
+> **關於部署到遠端主機**：`web` 容器把 `NEXT_PUBLIC_API_URL` 烘進前端 build（Next.js 對 client-side 環境變數的限制，容器啟動後才給的環境變數對它沒作用）。本機用預設值 `http://localhost:3001` 沒問題；要放到遠端主機，先在 `.env` 把 `NEXT_PUBLIC_API_URL` 改成 API 對外實際可連到的網址，並視需要設定 `WEB_ORIGIN` 收斂 CORS，然後重新 `docker compose --profile full build web`。
+>
+> **註：這份 docker-compose 設定在本次修改中已對照目前完整程式碼修正過（補上 M8 的 `AI_ENABLED`/`ANTHROPIC_API_KEY`、Redis 健康檢查與啟動順序、`prisma` CLI 缺漏等問題），並額外挖到一個原本會讓 `apps/api` 的容器建置直接失敗的問題：pnpm v10 預設不允許 `pnpm deploy` 部署未設定 `inject-workspace-packages=true` 的 workspace（會丟 `ERR_PNPM_DEPLOY_NONINJECTED_WORKSPACE`），已透過新增根目錄 `.npmrc` 修好，並在本機直接跑過一次 `pnpm --filter @azure-voyage/api --prod deploy` 確認輸出（`dist/`、`prisma/`、`node_modules/.bin/prisma`、注入的 `@azure-voyage/shared`）齊全。但受限於目前開發環境的網路政策無法連線到 Docker Hub 拉取基礎映像，所以沒能在這裡實際跑一次 `docker compose up` 把容器建置到底跑完。麻煩您在本機或伺服器上驗證一次；如果跑起來有任何問題，把錯誤訊息貼給我，我可以繼續修。**
+
 ## 如何遊玩
 
 1. **啟航**：建立世界後直接停靠在起始港，艦隊已配好一艘船與兩名航海士。

--- a/azure-voyage/apps/api/Dockerfile
+++ b/azure-voyage/apps/api/Dockerfile
@@ -3,7 +3,7 @@ RUN corepack enable
 WORKDIR /repo
 
 FROM base AS build
-COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
+COPY pnpm-workspace.yaml package.json pnpm-lock.yaml .npmrc ./
 COPY packages ./packages
 COPY apps/api ./apps/api
 RUN pnpm install --frozen-lockfile
@@ -13,6 +13,5 @@ RUN pnpm --filter @azure-voyage/api --prod deploy /out
 FROM node:22-alpine
 WORKDIR /app
 COPY --from=build /out .
-COPY --from=build /repo/apps/api/dist ./dist
 EXPOSE 3001
 CMD ["sh", "-c", "npx prisma migrate deploy && node dist/main.js"]

--- a/azure-voyage/apps/api/package.json
+++ b/azure-voyage/apps/api/package.json
@@ -29,6 +29,7 @@
     "bullmq": "^5.79.2",
     "fastify": "^5.8.5",
     "ioredis": "^5.11.1",
+    "prisma": "^6.2.1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "socket.io": "^4.8.1",
@@ -42,7 +43,6 @@
     "@types/jest": "^29.5.14",
     "@types/node": "^22.10.5",
     "jest": "^29.7.0",
-    "prisma": "^6.2.1",
     "ts-jest": "^29.2.5",
     "typescript": "^5.7.2"
   },

--- a/azure-voyage/apps/api/src/main.ts
+++ b/azure-voyage/apps/api/src/main.ts
@@ -9,7 +9,9 @@ async function bootstrap(): Promise<void> {
   );
   app.setGlobalPrefix("api/v1");
   app.enableCors({
-    origin: process.env.WEB_ORIGIN ?? true, // 開發預設全開；正式環境設 WEB_ORIGIN
+    // 開發預設全開；正式環境設 WEB_ORIGIN。空字串（如未設定時被解析成 ""）
+    // 視同未設定，否則 CORS 會把所有來源都擋下。
+    origin: process.env.WEB_ORIGIN || true,
     credentials: true,
   });
   app.enableShutdownHooks();

--- a/azure-voyage/docker-compose.yml
+++ b/azure-voyage/docker-compose.yml
@@ -21,8 +21,14 @@ services:
       - "6379:6379"
     volumes:
       - redisdata:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
 
-  # api / web 容器供正式部署用；日常開發用 `pnpm dev`（只起 postgres + redis）
+  # api / web 容器供 docker compose --profile full up --build 一鍵試玩用；
+  # 日常開發用 `pnpm dev`（只起 postgres + redis，程式碼跑在本機、有熱重載）。
   api:
     profiles: ["full"]
     build:
@@ -33,10 +39,16 @@ services:
       REDIS_URL: redis://redis:6379
       JWT_SECRET: ${JWT_SECRET:-dev-only-secret-change-me}
       API_PORT: 3001
+      # AI 層（docs/06、M8）：預設關閉，全走規則引擎 fallback，不需要 API key。
+      # 要讓 NPC 策略／世界事件改由 Claude 生成，在根目錄 .env 設定這兩個值。
+      AI_ENABLED: ${AI_ENABLED:-false}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
     ports:
       - "3001:3001"
     depends_on:
       postgres:
+        condition: service_healthy
+      redis:
         condition: service_healthy
 
   web:
@@ -44,8 +56,11 @@ services:
     build:
       context: .
       dockerfile: apps/web/Dockerfile
-    environment:
-      NEXT_PUBLIC_API_URL: http://localhost:3001
+      args:
+        # 建置期就烘進前端 bundle（Next.js public env 的限制）；本機 docker compose
+        # 玩的話用預設值即可（瀏覽器與 api 都在同一台機器，走 published port）。
+        # 部署到遠端主機時要改成 API 實際對外可連到的網址，並重新 build。
+        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:3001}
     ports:
       - "3000:3000"
     depends_on:

--- a/azure-voyage/pnpm-lock.yaml
+++ b/azure-voyage/pnpm-lock.yaml
@@ -3,6 +3,7 @@ lockfileVersion: '9.0'
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
+  injectWorkspacePackages: true
 
 importers:
 
@@ -80,6 +81,9 @@ importers:
       ioredis:
         specifier: ^5.11.1
         version: 5.11.1
+      prisma:
+        specifier: ^6.2.1
+        version: 6.19.3(typescript@5.9.3)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -114,9 +118,6 @@ importers:
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@22.20.0)
-      prisma:
-        specifier: ^6.2.1
-        version: 6.19.3(typescript@5.9.3)
       ts-jest:
         specifier: ^29.2.5
         version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.20.0))(typescript@5.9.3)


### PR DESCRIPTION
## Summary

Dockerizes the current M0–M9 codebase so it can be tested/played entirely via `docker compose --profile full up --build`, without touching a local Node/pnpm/Postgres/Redis install (as requested).

The Dockerfiles have existed since M0 but were never actually build-tested against the full codebase. Testing the API image's `pnpm --prod deploy` step directly on the host (Docker registry pulls are blocked by this sandbox's network policy, see Test plan) surfaced a real, previously-undiscovered bug:

- **pnpm v10 refuses `pnpm deploy` on a workspace unless `inject-workspace-packages=true` is set** — the API container build would have failed outright with `ERR_PNPM_DEPLOY_NONINJECTED_WORKSPACE`. Fixed with a new root `.npmrc`, copied into the API Dockerfile's build context.

Other fixes bundled in:
- Move `prisma` CLI from `devDependencies` to `dependencies` in `apps/api` — `pnpm --prod deploy` strips devDependencies, and the container's startup command needs `npx prisma migrate deploy` to actually work.
- Add `.dockerignore` so the build context doesn't ship host `node_modules`/build artifacts (with host-arch native bindings) into the Alpine/musl containers.
- `docker-compose.yml`: add a Redis healthcheck and gate the `api` service on it, pass through `AI_ENABLED`/`ANTHROPIC_API_KEY`, and move `NEXT_PUBLIC_API_URL` to a `web` build arg (Next.js bakes `NEXT_PUBLIC_*` vars in at build time, so a runtime `environment:` entry was dead config).
- `main.ts`: `process.env.WEB_ORIGIN || true` instead of `??`, so an empty-string env value also falls back to permissive CORS instead of silently blocking every origin.
- README: documents the `docker compose --profile full up --build` quick-start flow and is transparent about what was/wasn't verified (see below).

## Test plan

- [x] `pnpm lint`, `pnpm typecheck`, `pnpm build`, `pnpm test` all pass on this branch.
- [x] Verified the exact command the API Dockerfile runs (`pnpm --filter @azure-voyage/api --prod deploy <dir>`) directly on the host, both before and after the `.npmrc` fix — confirmed it now succeeds and the output directory contains `dist/main.js`, `prisma/schema.prisma` + migrations, `node_modules/.bin/prisma`, `node_modules/@prisma/client`, and a self-contained injected copy of `@azure-voyage/shared`.
- [ ] **Not verified**: an actual `docker compose --profile full up --build` end-to-end run. This sandbox's network policy blocks all Docker Hub/GHCR/public-ECR image pulls (confirmed 403 across three registries via the agent proxy), so the container build itself could not be executed here. Please run `docker compose --profile full up --build` on your machine and report back if anything else surfaces — the pnpm-deploy fix above was the most likely hard-failure point and that part is now verified directly.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013kDwmPmYtbENLcfMzDdnNF

---
_Generated by [Claude Code](https://claude.ai/code/session_013kDwmPmYtbENLcfMzDdnNF)_