### PR TITLE
azure-voyage: fix web Dockerfile lockfile mismatch

### DIFF
--- a/azure-voyage/apps/web/Dockerfile
+++ b/azure-voyage/apps/web/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /repo
 FROM base AS build
 ARG NEXT_PUBLIC_API_URL=http://localhost:3001
 ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
-COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
+COPY pnpm-workspace.yaml package.json pnpm-lock.yaml .npmrc ./
 COPY packages ./packages
 COPY apps/web ./apps/web
 RUN pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary

Follow-up to #14. The user ran `docker compose --profile full up --build` for real — the `api` image built successfully (confirming the `.npmrc`/`inject-workspace-packages` fix works), but the `web` build failed:

```
ERR_PNPM_LOCKFILE_CONFIG_MISMATCH  Cannot proceed with the frozen installation.
The current "settings.injectWorkspacePackages" configuration doesn't match the value found in the lockfile
```

`pnpm-lock.yaml` now records `settings.injectWorkspacePackages: true` (baked in when the lockfile was regenerated after adding `.npmrc`). The web Dockerfile's `COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./` line never copied `.npmrc` into its build context, so its `pnpm install --frozen-lockfile` ran without that setting and conflicted with the lockfile.

Fix: add `.npmrc` to that `COPY` line, same as the API Dockerfile already does.

## Test plan

- [x] Simulated the Docker build context in a scratch directory (copied `pnpm-workspace.yaml`, `package.json`, `pnpm-lock.yaml`, `.npmrc`, `packages/`, `apps/web/` — the exact files the Dockerfile's early layers copy) and ran `pnpm install --frozen-lockfile` there; it now completes successfully instead of erroring.
- [x] This is the one-line fix for a failure the user hit on a real `docker compose --profile full up --build` run, so it directly addresses observed, real behavior rather than a hypothetical.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013kDwmPmYtbENLcfMzDdnNF

---
_Generated by [Claude Code](https://claude.ai/code/session_013kDwmPmYtbENLcfMzDdnNF)_