### PR TITLE
azure-voyage: fix missing Prisma client after pnpm deploy

### DIFF
--- a/azure-voyage/apps/api/Dockerfile
+++ b/azure-voyage/apps/api/Dockerfile
@@ -9,6 +9,7 @@ COPY apps/api ./apps/api
 RUN pnpm install --frozen-lockfile
 RUN pnpm --filter @azure-voyage/shared build && pnpm --filter @azure-voyage/api build
 RUN pnpm --filter @azure-voyage/api --prod deploy /out
+RUN cd /out && npx prisma generate
 
 FROM node:22-alpine
 WORKDIR /app

--- a/azure-voyage/apps/web/Dockerfile
+++ b/azure-voyage/apps/web/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /repo
 FROM base AS build
 ARG NEXT_PUBLIC_API_URL=http://localhost:3001
 ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
-COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
+COPY pnpm-workspace.yaml package.json pnpm-lock.yaml .npmrc ./
 COPY packages ./packages
 COPY apps/web ./apps/web
 RUN pnpm install --frozen-lockfile

--- a/azure-voyage/docker-compose.yml
+++ b/azure-voyage/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U voyage"]
+      test: ["CMD-SHELL", "pg_isready -U voyage -d azure_voyage"]
       interval: 5s
       timeout: 3s
       retries: 10


### PR DESCRIPTION
## Summary

Follow-up to #14/#15. With the `.npmrc` fix in place, the user got both images building and the containers actually starting — but `api` crashed immediately:

```
Error: Cannot find module '.prisma/client/default'
```

**Root cause**: `pnpm --filter @azure-voyage/api build` runs `prisma generate`, which writes the generated client into the *build stage's* `node_modules` tree (under `/repo`). The next step, `pnpm --filter @azure-voyage/api --prod deploy /out`, builds a completely separate `node_modules` tree for `/out` — it does not carry over or regenerate that companion `.prisma/client` output. So the deployed image ships `@prisma/client` (the package) without its generated code, and Node can't resolve `.prisma/client/default` at runtime.

Reproduced directly on the host: ran the exact `pnpm --prod deploy` command, confirmed `.prisma/client` doesn't exist anywhere under the output, then ran `npx prisma generate` with the deployed directory as cwd and confirmed it creates `node_modules/.pnpm/@prisma+client@.../node_modules/.prisma/client/default.js`. Fixed by adding that regenerate step immediately after `deploy` in the Dockerfile.

Also cleaned up an unrelated but noisy log spam the user's run surfaced: the postgres healthcheck (`pg_isready -U voyage`, no `-d`) defaults its target dbname to the username, so postgres logged `FATAL: database "voyage" does not exist` every 5 seconds even though the actual database (`azure_voyage`) and the app's real connection were fine. Added `-d azure_voyage` to match.

## Test plan

- [x] Reproduced the missing-module failure on the host by running the exact `pnpm --prod deploy` command from the Dockerfile and confirming no `.prisma/client` directory exists anywhere in the output.
- [x] Confirmed running `npx prisma generate` with the deployed directory as `cwd` creates the missing `.prisma/client/default.js`/`.d.ts` files, matching the Dockerfile fix.
- [x] This closes the loop on the user's real `docker compose --profile full up --build` run, which got as far as both images building and postgres/redis/web starting cleanly, with only `api` crashing on this exact error.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013kDwmPmYtbENLcfMzDdnNF

---
_Generated by [Claude Code](https://claude.ai/code/session_013kDwmPmYtbENLcfMzDdnNF)_