### PR TITLE
feat(m13): 港口進出過場動畫

### DIFF
--- a/azure-voyage/apps/web/src/app/globals.css
+++ b/azure-voyage/apps/web/src/app/globals.css
@@ -25,3 +25,61 @@ body {
 .label {
   @apply mb-1 block text-sm text-foam;
 }
+
+/* 港口進出過場（docs/10 §M13）：純 CSS 動畫，無任何美術資產 */
+@keyframes cutscene-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes cutscene-ship-depart {
+  from {
+    transform: translateX(0) scale(1);
+    opacity: 1;
+  }
+  to {
+    transform: translateX(70vw) scale(0.6);
+    opacity: 0;
+  }
+}
+
+@keyframes cutscene-ship-arrive {
+  from {
+    transform: translateX(-70vw) scale(0.6);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0) scale(1);
+    opacity: 1;
+  }
+}
+
+@keyframes cutscene-gull {
+  from {
+    transform: translateX(-10vw);
+  }
+  to {
+    transform: translateX(110vw);
+  }
+}
+
+.cutscene-overlay {
+  animation: cutscene-fade-in 400ms ease-out;
+}
+
+.cutscene-ship-depart {
+  animation: cutscene-ship-depart 1800ms ease-in forwards;
+  animation-delay: 500ms;
+}
+
+.cutscene-ship-arrive {
+  animation: cutscene-ship-arrive 1500ms ease-out forwards;
+}
+
+.cutscene-gull {
+  animation: cutscene-gull 3.2s linear infinite;
+}

--- a/azure-voyage/apps/web/src/app/play/[worldId]/page.tsx
+++ b/azure-voyage/apps/web/src/app/play/[worldId]/page.tsx
@@ -41,6 +41,17 @@ import { BattleScene } from "@/game/BattleScene";
 import { ExplorationPanel } from "@/game/ExplorationPanel";
 import { DiscoveryPanel } from "@/game/DiscoveryPanel";
 import { InfluencePanel } from "@/game/InfluencePanel";
+import { PortCutscene, type CutsceneState } from "@/game/PortCutscene";
+
+/** M13：使用者選過「不再顯示這個動畫」後永久跳過過場（不影響其他玩家/裝置） */
+const CUTSCENE_SKIP_KEY = "azure-voyage:skip-cutscenes";
+function cutscenesSkipped(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.localStorage.getItem(CUTSCENE_SKIP_KEY) === "1";
+}
+function skipCutscenesForever(): void {
+  window.localStorage.setItem(CUTSCENE_SKIP_KEY, "1");
+}
 
 type WsState = "connecting" | "joined" | "disconnected";
 
@@ -89,6 +100,7 @@ export default function PlayPage() {
   const [battleState, setBattleState] = useState<BattleStateView | null>(null);
   const [battleLog, setBattleLog] = useState<string[]>([]);
   const [victory, setVictory] = useState<ServerVictoryPayload | null>(null);
+  const [cutscene, setCutscene] = useState<CutsceneState | null>(null);
   const socketRef = useRef<Socket | null>(null);
   const tickRef = useRef<number>(0);
   const inFlightRef = useRef(false);
@@ -96,6 +108,11 @@ export default function PlayPage() {
   // tick delta 依艦隊 id 過濾（不能拿 fleets[0]：清單只含「該 tick 有航行」的艦隊，
   // 順序與歸屬都不保證是玩家自己的）
   const playerFleetIdRef = useRef<string | null>(null);
+  // M13：WS handler 註冊在只跑一次的 effect 裡，讀 state 會拿到掛載當下的
+  // 舊值（stale closure）；用 ref 讓 server:arrival 算航程摘要時能拿到最新艦隊資料。
+  const latestFleetRef = useRef<FleetTickDelta | null>(null);
+  const tripStartRef = useRef<{ tick: number; food: number; water: number } | null>(null);
+  const tripEventCountRef = useRef(0);
 
   useEffect(() => {
     if (!getAccessToken()) {
@@ -131,6 +148,7 @@ export default function PlayPage() {
         : payload.fleets[0];
       if (mine) {
         setFleetDelta(mine);
+        latestFleetRef.current = mine;
         if (mine.activity === "DOCKED" || mine.activity === "ANCHORED") setRoute(null);
       }
       if (payload.notices.length > 0) setNotice(payload.notices.join(" "));
@@ -139,10 +157,29 @@ export default function PlayPage() {
     });
     socket.on(WS_EVENTS.SERVER_ARRIVAL, (payload: ServerArrivalPayload) => {
       if (playerFleetIdRef.current && payload.fleetId !== playerFleetIdRef.current) return;
-      setNotice(`艦隊已抵達 ${portById(payload.portId).name}`);
+      // M13：入港過場的航程摘要——自出港以來累計，後端無感知
+      const start = tripStartRef.current;
+      const nowFood = latestFleetRef.current?.food ?? start?.food ?? 0;
+      const nowWater = latestFleetRef.current?.water ?? start?.water ?? 0;
+      const summary = {
+        days: start ? payload.tick - start.tick : 0,
+        food: start ? Math.max(0, start.food - nowFood) : 0,
+        water: start ? Math.max(0, start.water - nowWater) : 0,
+        events: tripEventCountRef.current,
+      };
+      tripStartRef.current = null;
+      tripEventCountRef.current = 0;
+      if (cutscenesSkipped()) {
+        setNotice(`艦隊已抵達 ${portById(payload.portId).name}`);
+      } else {
+        setCutscene({ kind: "arrival", portId: payload.portId, day: payload.tick, summary });
+      }
       api.getWorld(worldId).then(setSnapshot).catch(() => undefined);
     });
     socket.on(WS_EVENTS.SERVER_EVENT, (payload: ServerEventPayload) => {
+      if (!payload.fleetId || payload.fleetId === playerFleetIdRef.current) {
+        tripEventCountRef.current += 1;
+      }
       setNotice(payload.event.narrative);
       api.getWorld(worldId).then(setSnapshot).catch(() => undefined);
     });
@@ -222,16 +259,25 @@ export default function PlayPage() {
   const gameEnded = victory !== null || (snapshot ? snapshot.world.status !== "ACTIVE" : false);
 
   // ── 節奏器：SAILING 時依速度檔每隔 N ms 送出 client:advance ──
+  // M13：過場動畫期間暫停（與「暫停」檔語意一致，無資料面副作用）。
   useEffect(() => {
     const intervalMs = SPEED_PRESETS[speedIdx].intervalMs;
-    if (activity !== "SAILING" || intervalMs === 0 || battleId !== null || victory !== null) return;
+    if (
+      activity !== "SAILING" ||
+      intervalMs === 0 ||
+      battleId !== null ||
+      victory !== null ||
+      cutscene !== null
+    ) {
+      return;
+    }
     const timer = setInterval(() => {
       if (inFlightRef.current) return;
       inFlightRef.current = true;
       socketRef.current?.emit(WS_EVENTS.CLIENT_ADVANCE, { worldId, ticks: 1 });
     }, intervalMs);
     return () => clearInterval(timer);
-  }, [activity, speedIdx, worldId, battleId, victory]);
+  }, [activity, speedIdx, worldId, battleId, victory, cutscene]);
 
   /**
    * 樂觀更新艦隊活動狀態。世界剛建立、尚未收到任何 server:tick 時 fleetDelta
@@ -303,11 +349,14 @@ export default function PlayPage() {
     setError(null);
     try {
       if ((await ensureCourseChosen()) === "failed") return;
+      const departingPortId = currentPort?.portId;
       const r = await api.depart(worldId, fleet.id);
-      seedFleetActivity("SAILING", {
-        food: fleet.food + r.resupplied.food,
-        water: fleet.water + r.resupplied.water,
-      });
+      const foodAfter = fleet.food + r.resupplied.food;
+      const waterAfter = fleet.water + r.resupplied.water;
+      // M13：出港過場的航程摘要起點——後端無感知，純前端累計
+      tripStartRef.current = { tick: currentTick, food: foodAfter, water: waterAfter };
+      tripEventCountRef.current = 0;
+      seedFleetActivity("SAILING", { food: foodAfter, water: waterAfter });
       setNotice(
         r.resupplied.cost > 0
           ? `出港前完成補給：糧 +${r.resupplied.food}、水 +${r.resupplied.water}，花費 ${r.resupplied.cost} 金。`
@@ -315,6 +364,9 @@ export default function PlayPage() {
       );
       // 更新商會資金顯示
       api.getWorld(worldId).then(setSnapshot).catch(() => undefined);
+      if (departingPortId && !cutscenesSkipped()) {
+        setCutscene({ kind: "depart", portId: departingPortId, day: currentTick });
+      }
     } catch (err) {
       setError(err instanceof ApiError ? err.message : "出港失敗");
     }
@@ -372,10 +424,30 @@ export default function PlayPage() {
     socketRef.current?.emit(WS_EVENTS.CLIENT_STEER, { worldId, fleetId: fleet.id, heading: next });
   }
 
+  /** M13：過場結束（逾時／ESC／點擊跳過皆走這裡）。 */
+  function handleCutsceneDone() {
+    setCutscene(null);
+  }
+  /** M13：「不再顯示這個動畫」——存 localStorage 並立即跳過當次。 */
+  function handleCutsceneSkipForever() {
+    skipCutscenesForever();
+    setCutscene(null);
+  }
+
   // M12 鍵盤操舵：監聽器只掛載一次，透過 ref 讀最新的 handler 閉包，
   // 避免每次 render（尤其航行中每個 tick 都會 render）都重新綁定 window 監聽器。
-  const keyHandlersRef = useRef({ rotateHeading, handleThrottleUp, handleAnchorKey });
-  keyHandlersRef.current = { rotateHeading, handleThrottleUp, handleAnchorKey };
+  const keyHandlersRef = useRef({
+    rotateHeading,
+    handleThrottleUp,
+    handleAnchorKey,
+    cutsceneActive: cutscene !== null,
+  });
+  keyHandlersRef.current = {
+    rotateHeading,
+    handleThrottleUp,
+    handleAnchorKey,
+    cutsceneActive: cutscene !== null,
+  };
 
   useEffect(() => {
     function isTypingTarget(target: EventTarget | null): boolean {
@@ -390,6 +462,9 @@ export default function PlayPage() {
     function onKeyDown(e: KeyboardEvent) {
       if (isTypingTarget(e.target)) return;
       const h = keyHandlersRef.current;
+      // M13：過場動畫中吃掉所有遊戲操作鍵，避免同時操舵；ESC 跳過由
+      // PortCutscene 自己的監聽器處理（過場元件掛載時才存在，職責單純）。
+      if (h.cutsceneActive) return;
       switch (e.key) {
         case "ArrowLeft":
         case "a":
@@ -663,6 +738,14 @@ export default function PlayPage() {
           battleId={battleId}
           state={battleState}
           log={battleLog}
+        />
+      )}
+
+      {cutscene && (
+        <PortCutscene
+          state={cutscene}
+          onDone={handleCutsceneDone}
+          onSkipForever={handleCutsceneSkipForever}
         />
       )}
     </main>

--- a/azure-voyage/apps/web/src/game/PortCutscene.tsx
+++ b/azure-voyage/apps/web/src/game/PortCutscene.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useEffect } from "react";
+import { generatePortSilhouette, portById } from "@azure-voyage/shared";
+
+export interface CutsceneState {
+  kind: "depart" | "arrival";
+  portId: string;
+  day: number;
+  /** 僅入港過場帶：自出港以來的統計，前端自行累計，不需後端改動 */
+  summary?: { days: number; food: number; water: number; events: number };
+}
+
+interface PortCutsceneProps {
+  state: CutsceneState;
+  onDone: () => void;
+  onSkipForever: () => void;
+}
+
+const DEPART_MS = 2500;
+const ARRIVAL_MS = 2000;
+
+/**
+ * 港口進出過場（docs/10 §M13）：純 React overlay + CSS 動畫，零美術資產。
+ * 港口剪影用 shared 的確定性生成器，同一港永遠長一樣、彼此不同。
+ * 純前端狀態機，後端無感知；逾時自動收尾，斷線重連落在過場中也不會卡死。
+ */
+export function PortCutscene({ state, onDone, onSkipForever }: PortCutsceneProps) {
+  const port = portById(state.portId);
+  const silhouette = generatePortSilhouette(state.portId, port.size);
+  const duration = state.kind === "depart" ? DEPART_MS : ARRIVAL_MS;
+
+  useEffect(() => {
+    const timer = setTimeout(onDone, duration);
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onDone();
+      }
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      clearTimeout(timer);
+      window.removeEventListener("keydown", onKeyDown);
+    };
+    // duration/onDone 隨 state 變動才需要重掛：同一過場實例中途不應該被重置計時器
+  }, [state.kind, state.portId, state.day]);
+
+  return (
+    <div className="cutscene-overlay fixed inset-0 z-50 flex flex-col items-center justify-center overflow-hidden bg-gradient-to-b from-abyss via-wave to-abyss">
+      <button className="btn-ghost absolute right-4 top-4 text-sm" onClick={onDone}>
+        跳過（ESC）
+      </button>
+
+      <div className="pointer-events-none absolute inset-x-0 top-12 h-10">
+        <span className="cutscene-gull absolute text-lg text-foam/60">⌃</span>
+        <span
+          className="cutscene-gull absolute top-3 text-base text-foam/40"
+          style={{ animationDelay: "1.1s" }}
+        >
+          ⌃
+        </span>
+      </div>
+
+      <svg
+        viewBox={`0 0 ${silhouette.totalWidth} 60`}
+        className="h-40 w-full max-w-3xl opacity-90"
+        preserveAspectRatio="xMidYMax meet"
+      >
+        <rect x={0} y={54} width={silhouette.dockWidth} height={6} fill="#3a2716" />
+        {silhouette.buildings.map((b, i) => (
+          <g key={i} fill="#12283f" stroke="#08111f" strokeWidth={0.5}>
+            <rect x={b.x} y={54 - b.height} width={b.width} height={b.height} />
+            {b.roofPeak > 0 && (
+              <polygon
+                points={`${b.x},${54 - b.height} ${b.x + b.width / 2},${54 - b.height - b.roofPeak} ${b.x + b.width},${54 - b.height}`}
+              />
+            )}
+          </g>
+        ))}
+      </svg>
+
+      <svg
+        viewBox="0 0 24 10"
+        className={
+          "h-10 w-24 " + (state.kind === "depart" ? "cutscene-ship-depart" : "cutscene-ship-arrive")
+        }
+      >
+        <polygon points="1,5 9,2.4 21,5 9,7.6" fill="#7a5230" stroke="#3a2716" strokeWidth={0.4} />
+      </svg>
+
+      <div className="mt-6 text-center">
+        <h2 className="text-2xl font-bold text-gold">{port.name}</h2>
+        <p className="mt-1 text-slate-300">
+          第 {state.day} 日 {state.kind === "depart" ? "啟航" : "抵達"}
+        </p>
+        {state.kind === "arrival" && state.summary && (
+          <p className="mt-2 text-sm text-slate-400">
+            航行 {state.summary.days} 天 · 消耗糧 {state.summary.food}／水 {state.summary.water}
+            {state.summary.events > 0 ? ` · 途中發生 ${state.summary.events} 起事件` : ""}
+          </p>
+        )}
+      </div>
+
+      <label className="mt-6 flex items-center gap-2 text-xs text-slate-500">
+        <input
+          type="checkbox"
+          className="accent-gold"
+          onChange={(e) => {
+            if (e.target.checked) onSkipForever();
+          }}
+        />
+        不再顯示這個動畫
+      </label>
+    </div>
+  );
+}

--- a/azure-voyage/docs/10-voyage-experience-plan.md
+++ b/azure-voyage/docs/10-voyage-experience-plan.md
@@ -5,11 +5,17 @@
 > 原則沿用 docs/09：每個里程碑一個 PR、結束時遊戲可運行可驗證、`AI_ENABLED=false` 全程可玩、
 > 所有美術一律程式繪製原創圖形（禁用任何既有遊戲素材）、規則計算放 `packages/shared/src/rules/` 純函式＋單測。
 
-> **執行記錄**：M11、M12 已完成，設計與下方規格一致，僅一處實務調整——M12
-> 的預設出港航向改由前端在「玩家第一次按 ↑ 卻從未操舵過」時即時挑選
-> （`firstNavigableHeading`），而非在 depart() 內硬性要求；`setHeading`
-> 統一支援 DOCKED/SAILING/ANCHORED 三種狀態（與 `setRoute` 對稱），讓「方向鍵
-> 預先瞄準再出港」與「航行中隨時轉舵」共用同一支端點。
+> **執行記錄**：M11、M12、M13 已完成，設計與下方規格大致一致，實務調整：
+> - M12：預設出港航向改由前端在「玩家第一次按 ↑ 卻從未操舵過」時即時挑選
+>   （`firstNavigableHeading`），而非在 depart() 內硬性要求；`setHeading`
+>   統一支援 DOCKED/SAILING/ANCHORED 三種狀態（與 `setRoute` 對稱），讓「方向鍵
+>   預先瞄準再出港」與「航行中隨時轉舵」共用同一支端點。
+> - M13：剪影生成器改放 `packages/shared/src/rules/portSilhouette.ts`（而非文件原
+>   訂的 `apps/web/src/game/`）——`apps/web` 目前沒有配置任何單元測試執行器，放
+>   shared 才能真的用既有 vitest 基建寫「同 portId 同輸出」的確定性測試，也更符合
+>   docs/09 既定原則（純計算歸 shared）。「鏡頭 zoom」簡化為過場 overlay 全螢幕蓋
+>   住地圖再退場，而非真的操縱 SeaMap 的 Pixi 相機——效果等價（畫面轉場到港景再
+>   轉回），但不需要幫 SeaMap 開一支新的命令式 API，耦合小很多。
 
 ## 總覽與依賴順序
 

--- a/azure-voyage/packages/shared/src/index.ts
+++ b/azure-voyage/packages/shared/src/index.ts
@@ -17,6 +17,7 @@ export * from "./rules/hexmap";
 export * from "./rules/pathfind";
 export * from "./rules/movement";
 export * from "./rules/wind";
+export * from "./rules/portSilhouette";
 export * from "./rules/supplies";
 export * from "./rules/pricing";
 export * from "./rules/influence";

--- a/azure-voyage/packages/shared/src/rules/portSilhouette.test.ts
+++ b/azure-voyage/packages/shared/src/rules/portSilhouette.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { buildingCountForSize, generatePortSilhouette } from "./portSilhouette";
+
+describe("generatePortSilhouette", () => {
+  it("is deterministic for the same portId and size", () => {
+    const a = generatePortSilhouette("port.amber_gulf.aurelia", 2);
+    const b = generatePortSilhouette("port.amber_gulf.aurelia", 2);
+    expect(a).toEqual(b);
+  });
+
+  it("differs across port ids", () => {
+    const a = generatePortSilhouette("port.a", 2);
+    const b = generatePortSilhouette("port.b", 2);
+    expect(a).not.toEqual(b);
+  });
+
+  it("differs across sizes for the same port id", () => {
+    const a = generatePortSilhouette("port.x", 1);
+    const b = generatePortSilhouette("port.x", 3);
+    expect(a).not.toEqual(b);
+  });
+
+  it("building count increases with port size", () => {
+    expect(buildingCountForSize(1)).toBeLessThan(buildingCountForSize(2));
+    expect(buildingCountForSize(2)).toBeLessThan(buildingCountForSize(3));
+    for (const size of [1, 2, 3] as const) {
+      expect(generatePortSilhouette("port.x", size).buildings.length).toBe(buildingCountForSize(size));
+    }
+  });
+
+  it("lays out buildings left-to-right without overlap, within sane bounds", () => {
+    const s = generatePortSilhouette("port.y", 3);
+    let prevEnd = -Infinity;
+    for (const b of s.buildings) {
+      expect(b.x).toBeGreaterThanOrEqual(prevEnd);
+      expect(b.width).toBeGreaterThan(0);
+      expect(b.height).toBeGreaterThan(0);
+      expect(b.roofPeak).toBeGreaterThanOrEqual(0);
+      prevEnd = b.x + b.width;
+    }
+    expect(s.totalWidth).toBeGreaterThanOrEqual(prevEnd);
+    expect(s.totalWidth).toBeGreaterThanOrEqual(s.dockWidth);
+  });
+});

--- a/azure-voyage/packages/shared/src/rules/portSilhouette.ts
+++ b/azure-voyage/packages/shared/src/rules/portSilhouette.ts
@@ -1,0 +1,51 @@
+/**
+ * 港口剪影生成（docs/10 §M13）：純函式，依 portId + size 決定性產生一組
+ * 建築矩形，供前端過場動畫畫成 SVG。零美術資產——每港靠確定性隨機讓外觀
+ * 彼此不同但固定不變（同 portId 永遠長一樣）。
+ */
+import { Rng } from "./rng";
+
+export interface PortBuilding {
+  x: number;
+  width: number;
+  height: number;
+  /** 屋頂三角形高度；0＝平頂 */
+  roofPeak: number;
+}
+
+export interface PortSilhouette {
+  buildings: PortBuilding[];
+  dockWidth: number;
+  /** 剪影總寬度（最後一棟建築的右緣），供 SVG viewBox 使用 */
+  totalWidth: number;
+}
+
+function hashString(s: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h >>> 0;
+}
+
+/** 港口規模 1–3 → 建築數量（規模越大，剪影越密集）。 */
+export function buildingCountForSize(size: 1 | 2 | 3): number {
+  return 4 + size * 3;
+}
+
+export function generatePortSilhouette(portId: string, size: 1 | 2 | 3): PortSilhouette {
+  const rng = new Rng((hashString(portId) ^ Math.imul(size, 0x9e3779b1)) >>> 0);
+  const count = buildingCountForSize(size);
+  const buildings: PortBuilding[] = [];
+  let cursor = 4;
+  for (let i = 0; i < count; i++) {
+    const width = rng.int(10, 22);
+    const height = rng.int(18, 24 + size * 14);
+    const roofPeak = rng.chance(0.5) ? rng.int(3, 10) : 0;
+    buildings.push({ x: cursor, width, height, roofPeak });
+    cursor += width + rng.int(2, 6);
+  }
+  const dockWidth = 24 + size * 16;
+  return { buildings, dockWidth, totalWidth: Math.max(cursor, dockWidth) };
+}


### PR DESCRIPTION
## Summary

docs/10 計畫第三個里程碑：出港/入港不再是瞬間切換，改為輕量、可跳過的過場，入港附航程摘要。

**Shared（`rules/portSilhouette.ts`，純函式＋單測）**
- `generatePortSilhouette(portId, size)`：以港口 id 為 seed 確定性生成建築剪影矩形，同港永遠長一樣、不同港彼此不同，零美術資產。建築數量隨 `PortDef.size` 遞增
- **與文件建議路徑不同**：文件原訂放 `apps/web/src/game/portSilhouette.ts`，但 `apps/web` 目前完全沒有配置任何單元測試執行器（`test` script 只是個 echo 佔位），純計算函式放 shared 才能真的用既有 vitest 基建寫「同 portId 同輸出」的確定性測試，也更符合專案自訂原則（純計算歸 `packages/shared/src/rules/`）

**Web（`game/PortCutscene.tsx`）**
- 全螢幕 React overlay + CSS keyframes：碼頭與建築剪影（SVG）、滑動的船隻剪影、海鷗粒子、港名/日期牌匾，入港額外顯示**航程摘要**（航行天數、糧水消耗、途中事件數——出港起前端自行累計，不需後端改動）
- 逾時自動收尾（出港~2.5s／入港~2s），斷線重連落在過場中不會卡死；ESC 或按鈕可跳過；勾選「不再顯示」寫入 localStorage 永久跳過
- 簡化了文件原訂的「操縱 SeaMap 的 Pixi 相機 zoom」——改成過場 overlay 直接蓋住地圖再退場，視覺效果等價（畫面轉場到港景再轉回），但不需要幫 SeaMap 開一支新的命令式 API，耦合小很多

**Play page 整合**
- `handleDepart` 在 API 呼叫成功後才記錄航程起點統計並顯示出港過場（失敗絕不進過場）；`server:arrival` 用 ref 讀最新艦隊資料算航程摘要（socket handler 只註冊一次，直接讀 state 會拿到過期值）並顯示入港過場，跳過模式下退回原本的純文字通知
- tick 節奏器新增過場暫停（等同「暫停」檔語意）；鍵盤監聽器在過場期間吃掉所有遊戲操作鍵，避免底下同時操舵

## Test plan

- [x] 新增 5 個 shared 單測（確定性、跨港/跨規模差異、建築數量隨規模遞增、不重疊排列）；shared 130、API 108 全綠
- [x] `pnpm lint` / `typecheck` / `build` 全綠
- [x] Playwright 實機驗證完整流程：出港過場出現並準時自動收尾 → 入港過場顯示正確航程摘要並自動收尾 → 「不再顯示」立即跳過並寫入 localStorage → 之後的航行不再出現過場；並重跑 M10/M11/M12 既有迴歸測試確認過場不干擾既有流程（Playwright 的可操作性重試會自然等過場退場）

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013kDwmPmYtbENLcfMzDdnNF

---
_Generated by [Claude Code](https://claude.ai/code/session_013kDwmPmYtbENLcfMzDdnNF)_