### PR TITLE
feat(m15): 程式美術大改版——古典海圖、船長室 UI、資產管線

### DIFF
--- a/azure-voyage/apps/web/src/app/globals.css
+++ b/azure-voyage/apps/web/src/app/globals.css
@@ -2,28 +2,127 @@
 @tailwind components;
 @tailwind utilities;
 
-body {
-  @apply bg-abyss text-slate-100 antialiased;
+/* ── M15 主題：古典航海圖×船長室（docs/11 §1）──
+   全程式材質：漸層＋內陰影＋SVG noise，無任何外部圖檔。 */
+
+:root {
+  --font-display: "Palatino Linotype", Palatino, Georgia, "Noto Serif TC", "Songti TC", serif;
+  /* 羊皮紙噪點（data-uri SVG，fractalNoise 疊在深色底上做材質） */
+  --texture-noise: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3CfeColorMatrix values='0 0 0 0 1 0 0 0 0 0.9 0 0 0 0 0.7 0 0 0 0.05 0'/%3E%3C/filter%3E%3Crect width='120' height='120' filter='url(%23n)'/%3E%3C/svg%3E");
 }
 
+@layer base {
+  body {
+    @apply text-slate-100 antialiased;
+    background-color: #08111f;
+    /* 注意：不用 background-attachment: fixed——Chromium 對「固定大背景層＋
+       持續重繪的 canvas」的合成成本極高，headless 截圖甚至會逾時。 */
+    background-image:
+      radial-gradient(ellipse at 20% -10%, rgba(31, 79, 122, 0.35), transparent 55%),
+      radial-gradient(ellipse at 90% 110%, rgba(58, 39, 22, 0.4), transparent 50%),
+      var(--texture-noise);
+  }
+
+  h1,
+  h2,
+  h3 {
+    font-family: var(--font-display);
+    letter-spacing: 0.03em;
+  }
+}
+
+/* 自訂元件類別一律放 components layer：讓元素上的 tailwind utility
+   （如 w-32 蓋掉 .input 的 w-full）能正常覆寫。 */
+@layer components {
+/* 船長室木質面板：深木色漸層 + 金線雙框 + 噪點材質 */
 .panel {
-  @apply rounded-lg border border-wave bg-wave/60 p-6 shadow-lg;
+  @apply relative rounded-lg p-6 shadow-lg;
+  border: 1px solid rgba(217, 164, 65, 0.35);
+  background-color: rgba(18, 40, 63, 0.72);
+  background-image:
+    linear-gradient(160deg, rgba(58, 39, 22, 0.28), rgba(18, 40, 63, 0.15) 45%, rgba(11, 21, 38, 0.35)),
+    var(--texture-noise);
+  box-shadow:
+    inset 0 0 0 1px rgba(8, 17, 31, 0.8),
+    inset 0 0 24px rgba(8, 17, 31, 0.55),
+    0 6px 18px rgba(0, 0, 0, 0.45);
+}
+/* 面板四角的黃銅鉚釘 */
+.panel::before,
+.panel::after {
+  content: "";
+  position: absolute;
+  width: 6px;
+  height: 6px;
+  border-radius: 9999px;
+  background: radial-gradient(circle at 35% 35%, #f0d08a, #d9a441 55%, #7a5230);
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.6);
+}
+.panel::before {
+  top: 7px;
+  left: 7px;
+}
+.panel::after {
+  top: 7px;
+  right: 7px;
+}
+
+/* 面板內主標題：襯線字 + 金色 + 底部裝飾線 */
+.panel h3 {
+  @apply text-gold;
 }
 
 .btn {
-  @apply inline-flex items-center justify-center rounded-md bg-gold px-4 py-2 font-medium text-abyss transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-50;
+  @apply inline-flex items-center justify-center rounded-md px-4 py-2 font-medium text-abyss transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-50;
+  background: linear-gradient(180deg, #f0d08a, #d9a441 55%, #b8862f);
+  border: 1px solid #7a5230;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 245, 220, 0.55),
+    0 2px 6px rgba(0, 0, 0, 0.4);
+  text-shadow: 0 1px 0 rgba(255, 245, 220, 0.4);
 }
 
 .btn-ghost {
-  @apply inline-flex items-center justify-center rounded-md border border-foam/40 px-4 py-2 text-foam transition hover:bg-foam/10;
+  @apply inline-flex items-center justify-center rounded-md px-4 py-2 text-foam transition hover:bg-foam/10;
+  border: 1px solid rgba(159, 195, 224, 0.45);
+  box-shadow: inset 0 0 0 1px rgba(8, 17, 31, 0.4);
 }
 
 .input {
-  @apply w-full rounded-md border border-foam/30 bg-abyss px-3 py-2 text-slate-100 outline-none focus:border-gold;
+  @apply w-full rounded-md px-3 py-2 text-slate-100 outline-none;
+  background-color: rgba(8, 17, 31, 0.85);
+  border: 1px solid rgba(159, 195, 224, 0.3);
+  box-shadow: inset 0 2px 6px rgba(0, 0, 0, 0.45);
+}
+.input:focus {
+  border-color: #d9a441;
+  box-shadow:
+    inset 0 2px 6px rgba(0, 0, 0, 0.45),
+    0 0 0 1px rgba(217, 164, 65, 0.35);
 }
 
 .label {
   @apply mb-1 block text-sm text-foam;
+}
+
+/* 章節標題裝飾：兩側漸淡的金色分隔線 */
+.rule-title {
+  @apply flex items-center gap-3 text-gold;
+  font-family: var(--font-display);
+}
+.rule-title::before,
+.rule-title::after {
+  content: "";
+  height: 1px;
+  flex: 1;
+  background: linear-gradient(90deg, transparent, rgba(217, 164, 65, 0.5), transparent);
+}
+}
+
+/* .font-serif 覆寫 tailwind 內建（放 utilities 之外維持原優先序） */
+.font-serif {
+  font-family: var(--font-display);
+  letter-spacing: 0.03em;
 }
 
 /* 港口進出過場（docs/10 §M13）：純 CSS 動畫，無任何美術資產 */

--- a/azure-voyage/apps/web/src/app/play/[worldId]/page.tsx
+++ b/azure-voyage/apps/web/src/app/play/[worldId]/page.tsx
@@ -43,6 +43,7 @@ import { ExplorationPanel } from "@/game/ExplorationPanel";
 import { DiscoveryPanel } from "@/game/DiscoveryPanel";
 import { InfluencePanel } from "@/game/InfluencePanel";
 import { PortCutscene, type CutsceneState } from "@/game/PortCutscene";
+import { PortBanner } from "@/game/PortBanner";
 
 /** M13：使用者選過「不再顯示這個動畫」後永久跳過過場（不影響其他玩家/裝置） */
 const CUTSCENE_SKIP_KEY = "azure-voyage:skip-cutscenes";
@@ -637,6 +638,8 @@ export default function PlayPage() {
             weather={weather}
             stormFlashTrigger={stormFlashTrigger}
           />
+
+          {activity === "DOCKED" && currentPort && <PortBanner portId={currentPort.portId} />}
 
           <section className="panel flex flex-wrap items-center gap-4">
             {activity === "DOCKED" && currentPort && (

--- a/azure-voyage/apps/web/src/game/GameArt.tsx
+++ b/azure-voyage/apps/web/src/game/GameArt.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+
+/**
+ * 資產管線的前端端點（docs/11 §3）：嘗試載入 `public/art/<category>/<id>.webp`，
+ * 不存在或載入失敗時渲染 fallback（程式繪製版）。缺任何一張圖遊戲照常可玩——
+ * 美術資產是漸進增強，不是硬相依。
+ */
+
+/** 已知缺檔快取：同一張缺圖只嘗試一次，重渲染不再打 404。 */
+const missing = new Set<string>();
+
+export interface GameArtProps {
+  category: "port-scene" | "portrait" | "ship" | "key-visual" | "battle-bg" | "event" | "goods";
+  id: string;
+  alt: string;
+  className?: string;
+  fallback: ReactNode;
+}
+
+export function GameArt({ category, id, alt, className, fallback }: GameArtProps) {
+  const key = `${category}/${id}`;
+  const [failed, setFailed] = useState(missing.has(key));
+
+  if (failed) return <>{fallback}</>;
+  return (
+    // 一般 <img>（而非 next/image）：資產是可缺席的靜態檔案，需要 onError fallback
+    // 語意，且不想為每張圖配置 next/image 的尺寸最佳化管線。
+    <img
+      src={`/art/${key}.webp`}
+      alt={alt}
+      className={className}
+      onError={() => {
+        missing.add(key);
+        setFailed(true);
+      }}
+    />
+  );
+}

--- a/azure-voyage/apps/web/src/game/PortBanner.tsx
+++ b/azure-voyage/apps/web/src/game/PortBanner.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { generatePortSilhouette, portById, regionForCoord } from "@azure-voyage/shared";
+import { GameArt } from "./GameArt";
+
+/**
+ * 停靠面板頂部的港口場景橫幅（docs/11 §3 整合點 A）。
+ * 有 `art/port-scene/<regionId>-s<size>.webp` 就顯示場景圖；沒有就用
+ * M13 的確定性剪影生成器畫一張「夜港剪影」——同港永遠同構圖。
+ */
+export function PortBanner({ portId }: { portId: string }) {
+  const port = portById(portId);
+  const region = regionForCoord(port.coord);
+  const artId = `${region.id.replace("region.", "")}-s${port.size}`;
+
+  return (
+    <div className="relative h-28 overflow-hidden rounded-lg border border-gold/30 md:h-36">
+      <GameArt
+        category="port-scene"
+        id={artId}
+        alt={`${port.name}港景`}
+        className="h-full w-full object-cover"
+        fallback={<SilhouetteBanner portId={portId} />}
+      />
+      <div className="absolute inset-0 bg-gradient-to-t from-abyss/90 via-transparent to-transparent" />
+      <div className="absolute bottom-2 left-4">
+        <span className="font-serif text-xl font-bold tracking-wide text-gold drop-shadow">
+          {port.name}
+        </span>
+        <span className="ml-3 text-xs text-foam/80">
+          {region.name} · 規模 {"⭐".repeat(port.size)}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function SilhouetteBanner({ portId }: { portId: string }) {
+  const port = portById(portId);
+  const s = generatePortSilhouette(portId, port.size);
+
+  return (
+    <svg
+      viewBox={`0 0 ${s.totalWidth} 60`}
+      className="h-full w-full"
+      preserveAspectRatio="xMidYMax slice"
+      role="img"
+      aria-label={`${port.name}剪影`}
+    >
+      <defs>
+        <linearGradient id={`sky-${portId}`} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="#0b1526" />
+          <stop offset="70%" stopColor="#1d3352" />
+          <stop offset="100%" stopColor="#2a4568" />
+        </linearGradient>
+      </defs>
+      <rect width={s.totalWidth} height={60} fill={`url(#sky-${portId})`} />
+      <circle cx={s.totalWidth * 0.78} cy={14} r={5} fill="#f5eedc" opacity={0.85} />
+      <rect x={0} y={54} width={s.dockWidth} height={6} fill="#3a2716" />
+      {s.buildings.map((b, i) => (
+        <g key={i} fill="#101f33" stroke="#08111f" strokeWidth={0.5}>
+          <rect x={b.x} y={54 - b.height} width={b.width} height={b.height} />
+          {b.roofPeak > 0 && (
+            <polygon
+              points={`${b.x},${54 - b.height} ${b.x + b.width / 2},${54 - b.height - b.roofPeak} ${b.x + b.width},${54 - b.height}`}
+            />
+          )}
+          {/* 幾扇亮著燭光的窗，讓夜港剪影有生活感（確定性：以序號取模） */}
+          {b.width >= 12 && b.height >= 24 && (
+            <rect
+              x={b.x + 3 + (i % 3) * 2}
+              y={54 - b.height + 6 + (i % 4) * 3}
+              width={2}
+              height={3}
+              fill="#d9a441"
+              stroke="none"
+              opacity={0.9}
+            />
+          )}
+        </g>
+      ))}
+    </svg>
+  );
+}

--- a/azure-voyage/apps/web/src/game/SeaMap.tsx
+++ b/azure-voyage/apps/web/src/game/SeaMap.tsx
@@ -18,12 +18,26 @@ import {
 import { hexCorners, hexToPixel, pixelToHex } from "./hexPixel";
 
 const TERRAIN_COLOR: Record<string, number> = {
-  [TERRAIN.DEEP]: 0x0b2e4d,
-  [TERRAIN.SHALLOW]: 0x1f6fa8,
+  [TERRAIN.DEEP]: 0x0c3050,
+  [TERRAIN.SHALLOW]: 0x1d5f92,
   [TERRAIN.REEF]: 0x8a6d3b,
-  [TERRAIN.LAND]: 0x2e5d3f,
+  [TERRAIN.LAND]: 0x35543a,
   [TERRAIN.PORT]: 0xd9a441,
 };
+/** M15 古典海圖風：每種地形的抖動替代色（約 1/4 格），打破整片平色的塑膠感 */
+const TERRAIN_COLOR_ALT: Record<string, number> = {
+  [TERRAIN.DEEP]: 0x0e3558,
+  [TERRAIN.SHALLOW]: 0x216aa0,
+  [TERRAIN.REEF]: 0x7d6236,
+  [TERRAIN.LAND]: 0x2e4a34,
+  [TERRAIN.PORT]: 0xd9a441,
+};
+/**
+ * hex 邊 e（連接 hexCorners 的第 e 與 e+1 個頂點）對應的鄰居方位。
+ * pointy-top 頂點自 -30° 起每 60° 一個（螢幕座標 y 向下），邊中點依序落在
+ * 0°/60°/120°/180°/240°/300° → 東、東南、西南、西、西北、東北。
+ */
+const EDGE_TO_DIR = [0, 5, 4, 3, 2, 1] as const;
 
 /** 航跡最長保留時間（毫秒）；點與點之間的取樣間隔 */
 const TRAIL_TTL_MS = 2600;
@@ -84,6 +98,14 @@ function buildShipSprite(): Container {
     ship.addChild(sail);
   }
   return ship;
+}
+
+/** 港口標記外環（visited 狀態變化時重繪） */
+function drawPortRing(g: Graphics, visited: boolean): void {
+  g.clear()
+    .circle(0, 0, 5.5)
+    .fill({ color: 0x08111f, alpha: 0.6 })
+    .stroke({ width: 1.4, color: visited ? 0xd9a441 : 0x6b7280, alpha: 0.95 });
 }
 
 /** 手繪虛線折線（pixi 無內建 dash） */
@@ -148,7 +170,9 @@ export function SeaMap({
   const trailGfxRef = useRef<Graphics | null>(null);
   const routeGfxRef = useRef<Graphics | null>(null);
   const destGfxRef = useRef<Graphics | null>(null);
-  const portVisualsRef = useRef<Map<string, { marker: Graphics; label: Text }>>(new Map());
+  const portVisualsRef = useRef<Map<string, { marker: Graphics; anchorGlyph: Text; label: Text }>>(
+    new Map(),
+  );
   const followRef = useRef(true);
   const fleetPosRef = useRef(fleetPos);
   fleetPosRef.current = fleetPos;
@@ -219,16 +243,38 @@ export function SeaMap({
         worldRef.current = world;
         app.stage.addChild(world);
 
-        // ── 地形（一次性烘焙）──
+        // ── 地形（一次性烘焙；M15 古典海圖風：雙色抖動＋水面細格線）──
         const terrain = new Graphics();
         for (let row = 0; row < HEXMAP.height; row++) {
           for (let col = 0; col < HEXMAP.width; col++) {
             const t = terrainAt(HEXMAP, { col, row });
             const center = hexToPixel({ col, row });
-            terrain.poly(hexCorners(center)).fill(TERRAIN_COLOR[t]);
+            const alt = ((col * 7 + row * 13) & 3) === 0; // 確定性抖動：不用亂數，重繪必一致
+            terrain.poly(hexCorners(center)).fill(alt ? TERRAIN_COLOR_ALT[t] : TERRAIN_COLOR[t]);
+            if (isNavigable(t)) {
+              terrain.poly(hexCorners(center)).stroke({ width: 0.4, color: 0x08111f, alpha: 0.16 });
+            }
           }
         }
         world.addChild(terrain);
+
+        // ── 海岸線描邊（M15）：陸地格朝水域的每一條邊畫砂色筆觸，
+        // 大陸輪廓立刻有手繪海圖的清晰感 ──
+        const coast = new Graphics();
+        for (let row = 0; row < HEXMAP.height; row++) {
+          for (let col = 0; col < HEXMAP.width; col++) {
+            if (terrainAt(HEXMAP, { col, row }) !== TERRAIN.LAND) continue;
+            const corners = hexCorners(hexToPixel({ col, row }));
+            for (let e = 0; e < 6; e++) {
+              const n = hexNeighborInDirection({ col, row }, EDGE_TO_DIR[e]);
+              if (!inBounds(HEXMAP, n) || !isNavigable(terrainAt(HEXMAP, n))) continue;
+              const e2 = ((e + 1) % 6) * 2;
+              coast.moveTo(corners[e * 2], corners[e * 2 + 1]).lineTo(corners[e2], corners[e2 + 1]);
+            }
+          }
+        }
+        coast.stroke({ width: 1.2, color: 0xc8b98a, alpha: 0.75 });
+        world.addChild(coast);
 
         // ── 航跡（畫在航線與港口之下）──
         const trailGfx = new Graphics();
@@ -248,14 +294,12 @@ export function SeaMap({
         destGfxRef.current = destGfx;
         world.addChild(destGfx);
 
-        // ── 港口標記 + 名稱標籤 ──
+        // ── 港口標記（金環＋錨徽）+ 名稱標籤 ──
         for (const port of PORTS) {
           const center = hexToPixel(port.coord);
           const visited = visitedRef.current.has(port.id);
-          const marker = new Graphics()
-            .circle(0, 0, 4)
-            .fill(visited ? 0xffe08a : 0x6b7280)
-            .stroke({ width: 1, color: 0x000000, alpha: 0.4 });
+          const marker = new Graphics();
+          drawPortRing(marker, visited);
           marker.position.set(center.x, center.y);
           marker.eventMode = "static";
           marker.cursor = "pointer";
@@ -265,22 +309,32 @@ export function SeaMap({
           });
           world.addChild(marker);
 
+          const anchorGlyph = new Text({
+            text: "⚓",
+            style: { fontSize: 6.5, fill: visited ? 0xffe08a : 0x9aa4b2 },
+            resolution: 3,
+          });
+          anchorGlyph.anchor.set(0.5);
+          anchorGlyph.position.set(center.x, center.y);
+          anchorGlyph.eventMode = "none";
+          world.addChild(anchorGlyph);
+
           const label = new Text({
             text: port.name,
             style: {
-              fontFamily: "system-ui, sans-serif",
+              fontFamily: "Palatino, Georgia, 'Noto Serif TC', serif",
               fontSize: 9,
-              fill: 0xdbe7f3,
+              fill: 0xe8dcc0,
               stroke: { color: 0x08111f, width: 2 },
             },
             resolution: 2,
           });
           label.anchor.set(0.5, 1);
-          label.position.set(center.x, center.y - 6);
+          label.position.set(center.x, center.y - 7);
           label.alpha = visited ? 0.95 : 0.5;
           world.addChild(label);
 
-          portVisualsRef.current.set(port.id, { marker, label });
+          portVisualsRef.current.set(port.id, { marker, anchorGlyph, label });
         }
 
         // ── M14 天氣視覺（世界座標圖層：隨地圖平移縮放）──
@@ -408,6 +462,36 @@ export function SeaMap({
 
         let fogAlpha = 0;
         let stormTintAlpha = 0;
+
+        // ── M15 地圖裝飾（螢幕座標）：雙金線外框 + 風向羅盤 ──
+        const frame = new Graphics();
+        frame.eventMode = "none";
+        app.stage.addChild(frame);
+        let frameW = 0;
+        let frameH = 0;
+
+        const compass = new Container();
+        compass.eventMode = "none";
+        const compassBase = new Graphics()
+          .circle(0, 0, 26)
+          .fill({ color: 0x08111f, alpha: 0.55 })
+          .stroke({ width: 1.5, color: 0xd9a441, alpha: 0.8 })
+          .circle(0, 0, 20)
+          .stroke({ width: 0.6, color: 0xd9a441, alpha: 0.45 });
+        // 八芒星刻度（古典羅盤的星芒）
+        for (let i = 0; i < 8; i++) {
+          const a = (Math.PI / 4) * i;
+          const len = i % 2 === 0 ? 18 : 11;
+          compassBase.moveTo(0, 0).lineTo(Math.cos(a) * len, Math.sin(a) * len);
+        }
+        compassBase.stroke({ width: 0.8, color: 0x9fc3e0, alpha: 0.55 });
+        compass.addChild(compassBase);
+        const windNeedle = new Graphics()
+          .poly([15, 0, -6, -4.5, -2, 0, -6, 4.5])
+          .fill(0xffe08a)
+          .stroke({ width: 0.6, color: 0x7a5230 });
+        compass.addChild(windNeedle);
+        app.stage.addChild(compass);
 
         // ── 主迴圈：船隻內插移動、轉向、航跡、目的地脈動、鏡頭跟隨 ──
         app.ticker.add(() => {
@@ -590,6 +674,29 @@ export function SeaMap({
               app.stage.position.set(0, 0);
             }
           }
+
+          // M15：地圖外框（尺寸變動時重畫）與羅盤（指針平滑轉向當日風向）
+          if (app.screen.width !== frameW || app.screen.height !== frameH) {
+            frameW = app.screen.width;
+            frameH = app.screen.height;
+            frame
+              .clear()
+              .rect(3, 3, frameW - 6, frameH - 6)
+              .stroke({ width: 1.5, color: 0xd9a441, alpha: 0.45 })
+              .rect(7, 7, frameW - 14, frameH - 14)
+              .stroke({ width: 0.6, color: 0xd9a441, alpha: 0.25 });
+          }
+          compass.position.set(app.screen.width - 46, app.screen.height - 46);
+          const windNow = windDirRef.current;
+          compass.visible = windNow !== null;
+          if (windNow !== null) {
+            // 與 HUD 箭頭同一約定：dir 0=東、逆時針；螢幕 y 向下故取負角
+            const targetRot = (-Math.PI / 3) * windNow;
+            let cd = targetRot - windNeedle.rotation;
+            while (cd > Math.PI) cd -= 2 * Math.PI;
+            while (cd < -Math.PI) cd += 2 * Math.PI;
+            windNeedle.rotation += cd * Math.min(1, dt * 5);
+          }
         });
       });
 
@@ -640,11 +747,8 @@ export function SeaMap({
       const vis = portVisualsRef.current.get(port.id);
       if (!vis) continue;
       const visited = visitedPortIds.has(port.id);
-      vis.marker
-        .clear()
-        .circle(0, 0, 4)
-        .fill(visited ? 0xffe08a : 0x6b7280)
-        .stroke({ width: 1, color: 0x000000, alpha: 0.4 });
+      drawPortRing(vis.marker, visited);
+      vis.anchorGlyph.style.fill = visited ? 0xffe08a : 0x9aa4b2;
       vis.label.alpha = visited ? 0.95 : 0.5;
     }
   }, [visitedPortIds]);

--- a/azure-voyage/apps/web/src/game/TavernShipyardPanel.tsx
+++ b/azure-voyage/apps/web/src/game/TavernShipyardPanel.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { OFFICER_ROLES, SHIP_CLASSES, type FleetView, type TavernOfficerView } from "@azure-voyage/shared";
 import { officerApi } from "@/lib/officerApi";
+import { GameArt } from "./GameArt";
 
 const ROLE_LABELS: Record<string, string> = {
   FIRST_MATE: "副官",
@@ -11,6 +12,23 @@ const ROLE_LABELS: Record<string, string> = {
   PURSER: "會計長",
   LOOKOUT: "瞭望員",
 };
+
+/** 航海士立繪縮圖：有 `art/portrait/<key>.webp` 就顯示，否則首字暖金頭像框（M15）。 */
+function OfficerAvatar({ portrait, name }: { portrait: string; name: string }) {
+  return (
+    <GameArt
+      category="portrait"
+      id={portrait.replace(/^portrait\./, "")}
+      alt={name}
+      className="h-12 w-10 shrink-0 rounded border border-gold/40 object-cover"
+      fallback={
+        <span className="flex h-12 w-10 shrink-0 items-center justify-center rounded border border-gold/40 bg-abyss font-serif text-lg text-gold">
+          {name.charAt(0)}
+        </span>
+      }
+    />
+  );
+}
 
 interface Props {
   worldId: string;
@@ -98,9 +116,12 @@ export function TavernShipyardPanel({ worldId, portId, fleet, onChanged }: Props
         ) : (
           <ul className="space-y-2">
             {tavern.map((o) => (
-              <li key={o.id} className="flex items-center justify-between rounded-md border border-foam/20 p-2 text-sm">
-                <span>
-                  {o.name} · 統率{o.stats.lead} 航海{o.stats.nav} 戰鬥{o.stats.combat} 商才{o.stats.trade} 學識
+              <li key={o.id} className="flex items-center gap-3 rounded-md border border-foam/20 p-2 text-sm">
+                <OfficerAvatar portrait={o.portrait} name={o.name} />
+                <span className="flex-1">
+                  <span className="font-serif text-base text-slate-100">{o.name}</span>
+                  <br />
+                  統率{o.stats.lead} 航海{o.stats.nav} 戰鬥{o.stats.combat} 商才{o.stats.trade} 學識
                   {o.stats.lore} · 薪 {o.salary}
                 </span>
                 <button className="btn-ghost" onClick={() => recruit(o.id)}>
@@ -114,8 +135,9 @@ export function TavernShipyardPanel({ worldId, portId, fleet, onChanged }: Props
         <h4 className="mb-2 mt-4 font-medium text-slate-200">艦隊航海士</h4>
         <ul className="space-y-2">
           {fleet.officers.map((o) => (
-            <li key={o.id} className="flex items-center justify-between rounded-md border border-foam/20 p-2 text-sm">
-              <span>
+            <li key={o.id} className="flex items-center gap-3 rounded-md border border-foam/20 p-2 text-sm">
+              <OfficerAvatar portrait={o.portrait} name={o.name} />
+              <span className="flex-1">
                 {o.name}（忠誠 {o.loyalty}）
               </span>
               <select


### PR DESCRIPTION
## Summary

docs/11 美術計畫第一個里程碑：**零外部資產**把整體觀感拉出工程原型感，並落地 M16 生圖資產要用的管線。

**海圖（SeaMap，全部初始化時一次烘焙，無逐幀成本）**
- 海岸線描邊：每個陸地格朝可航行水域的邊畫砂色筆觸（邊索引→鄰居方位映射自 pointy-top 頂點幾何推導），大陸輪廓立刻有手繪海圖感
- 雙色地形抖動（確定性座標 hash，非亂數，重繪必一致）＋水面細格線＋更豐富的深淺海/陸地配色
- 港口標記升級：金環徽章＋⚓字徽＋襯線字港名；造訪狀態同步重繪環/徽/標籤
- 螢幕座標海圖裝飾：雙金線外框（只在尺寸變動時重畫）＋八芒星羅盤，指針平滑追蹤 M11 每日風向——羅盤是儀器不只是裝飾

**UI 主題（globals.css）**
- 船長室面板：深木漸層＋inline SVG fractalNoise 材質（data URI，零圖檔）＋金邊＋黃銅鉚釘（偽元素）；鎏金漸層按鈕；標題襯線字族（純系統字體——沙盒抓不到 webfont，玩家也不該需要）
- 修掉一個被第一版暴露的 Tailwind 分層 bug：自訂類別宣告在 `@tailwind utilities` 之後，`.input` 的 `w-full` 蓋掉元素上的 `w-32/w-40`，下拉全被撐滿。包進 `@layer components` 恢復 utility 優先序
- 刻意**不用** `background-attachment: fixed`——Chromium 對「固定全頁背景層＋持續重繪 canvas」合成成本極高（headless 截圖直接逾時）

**資產管線（docs/11 §3，先於 M16 資產批次落地）**
- `GameArt` 元件：渲染 `/art/<category>/<id>.webp`，`onError` fallback 到程式繪製版＋模組級缺檔快取（缺圖只 404 一次）。**缺任何圖永不擋玩**
- `PortBanner`：停靠港橫幅走 GameArt；fallback 重用 M13 確定性剪影生成器畫成「夜港燭窗」SVG——今天每個港就已有各自不同的橫幅。酒館航海士列同樣走 GameArt 立繪（資產 key＝M1 內容包從一開始就帶著的 `portrait` 欄位），fallback 為襯線首字頭像框

## Test plan

- [x] lint／typecheck／build 全綠；shared 136＋API 109 測試不變全綠
- [x] Playwright 實機冒煙（production build）：剪影橫幅出現、頭像框渲染、海圖新視覺、全程零未捕捉 JS 錯誤；並重跑 M12 鍵盤操舵 e2e 驗證新 UI 不影響操作
- [x] 備註：本容器的 Next dev server 驗證期間反覆卡死（既有的不穩定性，與本次 CSS 無關），e2e 皆改對 `next start` production build 執行

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013kDwmPmYtbENLcfMzDdnNF

---
_Generated by [Claude Code](https://claude.ai/code/session_013kDwmPmYtbENLcfMzDdnNF)_