### PR TITLE
M16: 生圖管線 tools/artgen（P0 訂單表 + Gemini/Imagen 產圖腳本）

### DIFF
--- a/azure-voyage/apps/web/src/game/TavernShipyardPanel.tsx
+++ b/azure-voyage/apps/web/src/game/TavernShipyardPanel.tsx
@@ -30,6 +30,23 @@ function OfficerAvatar({ portrait, name }: { portrait: string; name: string }) {
   );
 }
 
+/** 船級縮圖：有 `art/ship/<classId>.webp` 就顯示，否則錨形指標佔位（M16）。 */
+function ShipClassThumb({ shipClassId, name }: { shipClassId: string; name: string }) {
+  return (
+    <GameArt
+      category="ship"
+      id={shipClassId.replace(/^ship\./, "")}
+      alt={name}
+      className="h-12 w-16 shrink-0 rounded border border-gold/40 object-cover"
+      fallback={
+        <span className="flex h-12 w-16 shrink-0 items-center justify-center rounded border border-gold/40 bg-abyss text-lg text-gold">
+          ⚓
+        </span>
+      }
+    />
+  );
+}
+
 interface Props {
   worldId: string;
   portId: string;
@@ -161,8 +178,9 @@ export function TavernShipyardPanel({ worldId, portId, fleet, onChanged }: Props
         <h3 className="mb-2 text-lg font-semibold text-foam">造船廠</h3>
         <ul className="mb-4 space-y-2">
           {fleet.ships.map((s) => (
-            <li key={s.id} className="flex items-center justify-between rounded-md border border-foam/20 p-2 text-sm">
-              <span>
+            <li key={s.id} className="flex items-center gap-3 rounded-md border border-foam/20 p-2 text-sm">
+              <ShipClassThumb shipClassId={s.shipClassId} name={s.name} />
+              <span className="flex-1">
                 {s.isFlagship ? "⚓ " : ""}
                 {s.name} · 耐久 {s.hull}
               </span>
@@ -178,6 +196,10 @@ export function TavernShipyardPanel({ worldId, portId, fleet, onChanged }: Props
           ))}
         </ul>
         <div className="flex flex-wrap items-end gap-2">
+          <ShipClassThumb
+            shipClassId={shipClassId}
+            name={SHIP_CLASSES.find((sc) => sc.id === shipClassId)?.name ?? shipClassId}
+          />
           <select className="input w-40" value={shipClassId} onChange={(e) => setShipClassId(e.target.value)}>
             {SHIP_CLASSES.map((sc) => (
               <option key={sc.id} value={sc.id}>

--- a/azure-voyage/pnpm-lock.yaml
+++ b/azure-voyage/pnpm-lock.yaml
@@ -195,6 +195,12 @@ importers:
 
   packages/tsconfig: {}
 
+  tools/artgen:
+    dependencies:
+      sharp:
+        specifier: ^0.33.5
+        version: 0.33.5
+
 packages:
 
   '@alloc/quick-lru@5.2.0':
@@ -800,10 +806,22 @@ packages:
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
 
+  '@img/sharp-darwin-arm64@0.33.5':
+    resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
   '@img/sharp-darwin-arm64@0.34.5':
     resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.33.5':
+    resolution: {integrity: sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
     os: [darwin]
 
   '@img/sharp-darwin-x64@0.34.5':
@@ -812,9 +830,19 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@img/sharp-libvips-darwin-arm64@1.0.4':
+    resolution: {integrity: sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@img/sharp-libvips-darwin-arm64@1.2.4':
     resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
     cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.0.4':
+    resolution: {integrity: sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==}
+    cpu: [x64]
     os: [darwin]
 
   '@img/sharp-libvips-darwin-x64@1.2.4':
@@ -822,9 +850,21 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@img/sharp-libvips-linux-arm64@1.0.4':
+    resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-libvips-linux-arm64@1.2.4':
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.0.5':
+    resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
+    cpu: [arm]
     os: [linux]
     libc: [glibc]
 
@@ -846,9 +886,21 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-libvips-linux-s390x@1.0.4':
+    resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.0.4':
+    resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
+    cpu: [x64]
     os: [linux]
     libc: [glibc]
 
@@ -858,9 +910,21 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
+    resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
+    resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
+    cpu: [x64]
     os: [linux]
     libc: [musl]
 
@@ -870,10 +934,24 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@img/sharp-linux-arm64@0.33.5':
+    resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.33.5':
+    resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
     os: [linux]
     libc: [glibc]
 
@@ -898,10 +976,24 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-linux-s390x@0.33.5':
+    resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.33.5':
+    resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
     os: [linux]
     libc: [glibc]
 
@@ -912,10 +1004,24 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-linuxmusl-arm64@0.33.5':
+    resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.33.5':
+    resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
     os: [linux]
     libc: [musl]
 
@@ -925,6 +1031,11 @@ packages:
     cpu: [x64]
     os: [linux]
     libc: [musl]
+
+  '@img/sharp-wasm32@0.33.5':
+    resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -937,10 +1048,22 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@img/sharp-win32-ia32@0.33.5':
+    resolution: {integrity: sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
   '@img/sharp-win32-ia32@0.34.5':
     resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.33.5':
+    resolution: {integrity: sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
     os: [win32]
 
   '@img/sharp-win32-x64@0.34.5':
@@ -2215,6 +2338,13 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  color-string@1.9.1:
+    resolution: {integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==}
+
+  color@4.2.3:
+    resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
+    engines: {node: '>=12.5.0'}
+
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
@@ -2769,6 +2899,9 @@ packages:
 
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  is-arrayish@0.3.4:
+    resolution: {integrity: sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==}
 
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
@@ -3687,6 +3820,10 @@ packages:
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
+  sharp@0.33.5:
+    resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -3708,6 +3845,9 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  simple-swizzle@0.2.4:
+    resolution: {integrity: sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==}
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
@@ -4762,9 +4902,19 @@ snapshots:
   '@img/colour@1.1.0':
     optional: true
 
+  '@img/sharp-darwin-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.0.4
+    optional: true
+
   '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.0.4
     optional: true
 
   '@img/sharp-darwin-x64@0.34.5':
@@ -4772,13 +4922,25 @@ snapshots:
       '@img/sharp-libvips-darwin-x64': 1.2.4
     optional: true
 
+  '@img/sharp-libvips-darwin-arm64@1.0.4':
+    optional: true
+
   '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.0.4':
     optional: true
 
   '@img/sharp-libvips-darwin-x64@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-linux-arm64@1.0.4':
+    optional: true
+
   '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.0.5':
     optional: true
 
   '@img/sharp-libvips-linux-arm@1.2.4':
@@ -4790,21 +4952,43 @@ snapshots:
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-linux-s390x@1.0.4':
+    optional: true
+
   '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.0.4':
     optional: true
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
+    optional: true
+
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     optional: true
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     optional: true
 
+  '@img/sharp-linux-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.0.4
+    optional: true
+
   '@img/sharp-linux-arm64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.0.5
     optional: true
 
   '@img/sharp-linux-arm@0.34.5':
@@ -4822,9 +5006,19 @@ snapshots:
       '@img/sharp-libvips-linux-riscv64': 1.2.4
     optional: true
 
+  '@img/sharp-linux-s390x@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.0.4
+    optional: true
+
   '@img/sharp-linux-s390x@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.0.4
     optional: true
 
   '@img/sharp-linux-x64@0.34.5':
@@ -4832,14 +5026,29 @@ snapshots:
       '@img/sharp-libvips-linux-x64': 1.2.4
     optional: true
 
+  '@img/sharp-linuxmusl-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
+    optional: true
+
   '@img/sharp-linuxmusl-arm64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
     optional: true
 
+  '@img/sharp-linuxmusl-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
+    optional: true
+
   '@img/sharp-linuxmusl-x64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.33.5':
+    dependencies:
+      '@emnapi/runtime': 1.11.2
     optional: true
 
   '@img/sharp-wasm32@0.34.5':
@@ -4850,7 +5059,13 @@ snapshots:
   '@img/sharp-win32-arm64@0.34.5':
     optional: true
 
+  '@img/sharp-win32-ia32@0.33.5':
+    optional: true
+
   '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.33.5':
     optional: true
 
   '@img/sharp-win32-x64@0.34.5':
@@ -6226,6 +6441,16 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  color-string@1.9.1:
+    dependencies:
+      color-name: 1.1.4
+      simple-swizzle: 0.2.4
+
+  color@4.2.3:
+    dependencies:
+      color-convert: 2.0.1
+      color-string: 1.9.1
+
   commander@2.20.3: {}
 
   commander@4.1.1: {}
@@ -6316,8 +6541,7 @@ snapshots:
 
   destr@2.0.5: {}
 
-  detect-libc@2.1.2:
-    optional: true
+  detect-libc@2.1.2: {}
 
   detect-newline@3.1.0: {}
 
@@ -6863,6 +7087,8 @@ snapshots:
   ipaddr.js@2.4.0: {}
 
   is-arrayish@0.2.1: {}
+
+  is-arrayish@0.3.4: {}
 
   is-binary-path@2.1.0:
     dependencies:
@@ -7920,6 +8146,32 @@ snapshots:
 
   set-cookie-parser@2.7.2: {}
 
+  sharp@0.33.5:
+    dependencies:
+      color: 4.2.3
+      detect-libc: 2.1.2
+      semver: 7.8.5
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.33.5
+      '@img/sharp-darwin-x64': 0.33.5
+      '@img/sharp-libvips-darwin-arm64': 1.0.4
+      '@img/sharp-libvips-darwin-x64': 1.0.4
+      '@img/sharp-libvips-linux-arm': 1.0.5
+      '@img/sharp-libvips-linux-arm64': 1.0.4
+      '@img/sharp-libvips-linux-s390x': 1.0.4
+      '@img/sharp-libvips-linux-x64': 1.0.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
+      '@img/sharp-linux-arm': 0.33.5
+      '@img/sharp-linux-arm64': 0.33.5
+      '@img/sharp-linux-s390x': 0.33.5
+      '@img/sharp-linux-x64': 0.33.5
+      '@img/sharp-linuxmusl-arm64': 0.33.5
+      '@img/sharp-linuxmusl-x64': 0.33.5
+      '@img/sharp-wasm32': 0.33.5
+      '@img/sharp-win32-ia32': 0.33.5
+      '@img/sharp-win32-x64': 0.33.5
+
   sharp@0.34.5:
     dependencies:
       '@img/colour': 1.1.0
@@ -7963,6 +8215,10 @@ snapshots:
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
+
+  simple-swizzle@0.2.4:
+    dependencies:
+      is-arrayish: 0.3.4
 
   sisteransi@1.0.5: {}
 

--- a/azure-voyage/pnpm-workspace.yaml
+++ b/azure-voyage/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - "apps/*"
   - "packages/*"
+  - "tools/*"

--- a/azure-voyage/tools/artgen/README.md
+++ b/azure-voyage/tools/artgen/README.md
@@ -1,0 +1,33 @@
+# tools/artgen
+
+M16 生圖管線（docs/11 §3 API 模式）。讀 `manifest.mjs` 的訂單表，呼叫 Google
+Generative Language API（Gemini / Imagen，動態探測可用模型），輸出 webp 到
+`apps/web/public/art/<category>/<id>.webp`，命名對應 `GameArt` 元件的資產 key。
+
+## 使用方式
+
+```bash
+cd tools/artgen
+pnpm install
+
+# 先 dry-run 看訂單表（不呼叫 API，不花配額）
+node generate.mjs --dry-run
+
+# 正式產生（key 只用環境變數，不要寫進任何檔案／不要 commit）
+GEMINI_API_KEY=xxx node generate.mjs
+
+# 只做某個 category 或某一筆，方便先測試/校色
+GEMINI_API_KEY=xxx node generate.mjs --only=ship
+GEMINI_API_KEY=xxx node generate.mjs --id=sera
+```
+
+## 安全性
+
+- **絕對不要**把 API key 寫進 `.env`、程式碼、commit message 或任何會被 `git add`
+  的檔案。此腳本只從 `process.env.GEMINI_API_KEY` 讀取，用完即丟。
+- 產生的圖片本身沒有秘密資訊，可以正常 commit 進 `apps/web/public/art/`。
+
+## 缺圖不擋玩
+
+`apps/web/src/game/GameArt.tsx` 對每張資產都有 fallback（剪影 / 字母頭像 / 待補），
+這裡沒跑完、跑失敗的項目，遊戲照常可玩。

--- a/azure-voyage/tools/artgen/generate.mjs
+++ b/azure-voyage/tools/artgen/generate.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+/**
+ * M16 生圖管線（docs/11 §3 API 模式）：讀 manifest.mjs → 呼叫 Google Generative Language
+ * API（Imagen `:predict` 或 Gemini 原生圖片輸出 `:generateContent`，動態探測可用模型，
+ * 不寫死型號）→ sharp 轉 webp 並縮放到目標尺寸 → 寫入 apps/web/public/art/<category>/<id>.webp。
+ *
+ * 用法：
+ *   GEMINI_API_KEY=xxx node generate.mjs              # 產生 manifest 全部項目
+ *   GEMINI_API_KEY=xxx node generate.mjs --only=ship  # 只做某 category
+ *   GEMINI_API_KEY=xxx node generate.mjs --id=sera    # 只做某一筆（id 精確比對）
+ *   node generate.mjs --dry-run                       # 不呼叫 API，只列出將產生的項目
+ *
+ * ⚠️ 不要把 API key 寫進任何檔案——一律用環境變數，用完即丟。
+ */
+
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import sharp from "sharp";
+import { MANIFEST, NEGATIVE_PROMPT } from "./manifest.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_ROOT = path.resolve(__dirname, "../../apps/web/public/art");
+const API_BASE = "https://generativelanguage.googleapis.com/v1beta";
+
+const args = process.argv.slice(2);
+const dryRun = args.includes("--dry-run");
+const onlyCategory = args.find((a) => a.startsWith("--only="))?.slice("--only=".length);
+const onlyId = args.find((a) => a.startsWith("--id="))?.slice("--id=".length);
+
+function selectEntries() {
+  return MANIFEST.filter((e) => (!onlyCategory || e.category === onlyCategory) && (!onlyId || e.id === onlyId));
+}
+
+async function listModels(apiKey) {
+  const res = await fetch(`${API_BASE}/models?pageSize=100&key=${apiKey}`);
+  if (!res.ok) {
+    throw new Error(`list models failed: HTTP ${res.status} ${await res.text()}`);
+  }
+  const body = await res.json();
+  return body.models ?? [];
+}
+
+/** 動態挑模型：優先 Imagen（:predict），其次支援圖片輸出的 Gemini（:generateContent）。 */
+function pickModel(models) {
+  const imagen = models.find(
+    (m) => /imagen/i.test(m.name) && (m.supportedGenerationMethods ?? []).includes("predict"),
+  );
+  if (imagen) return { name: imagen.name, kind: "imagen" };
+
+  const geminiImage = models.find(
+    (m) => /image/i.test(m.name) && (m.supportedGenerationMethods ?? []).includes("generateContent"),
+  );
+  if (geminiImage) return { name: geminiImage.name, kind: "gemini" };
+
+  throw new Error("no image-capable model found in this API key's model list");
+}
+
+async function callImagen(apiKey, modelName, prompt) {
+  const res = await fetch(`${API_BASE}/${modelName}:predict?key=${apiKey}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      instances: [{ prompt }],
+      parameters: { sampleCount: 1, negativePrompt: NEGATIVE_PROMPT },
+    }),
+  });
+  if (!res.ok) throw new Error(`imagen predict failed: HTTP ${res.status} ${await res.text()}`);
+  const body = await res.json();
+  const b64 = body.predictions?.[0]?.bytesBase64Encoded;
+  if (!b64) throw new Error(`imagen predict: no image bytes in response: ${JSON.stringify(body).slice(0, 300)}`);
+  return Buffer.from(b64, "base64");
+}
+
+async function callGeminiImage(apiKey, modelName, prompt) {
+  const res = await fetch(`${API_BASE}/${modelName}:generateContent?key=${apiKey}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      contents: [{ parts: [{ text: `${prompt}\n\nAvoid: ${NEGATIVE_PROMPT}` }] }],
+      generationConfig: { responseModalities: ["IMAGE"] },
+    }),
+  });
+  if (!res.ok) throw new Error(`gemini generateContent failed: HTTP ${res.status} ${await res.text()}`);
+  const body = await res.json();
+  const parts = body.candidates?.[0]?.content?.parts ?? [];
+  const imagePart = parts.find((p) => p.inlineData?.data);
+  if (!imagePart) throw new Error(`gemini generateContent: no image part in response: ${JSON.stringify(body).slice(0, 300)}`);
+  return Buffer.from(imagePart.inlineData.data, "base64");
+}
+
+async function generateOne(apiKey, model, entry, attempt = 1) {
+  try {
+    const buf =
+      model.kind === "imagen"
+        ? await callImagen(apiKey, model.name, entry.prompt)
+        : await callGeminiImage(apiKey, model.name, entry.prompt);
+    return buf;
+  } catch (err) {
+    if (attempt < 3 && /HTTP (429|5\d\d)/.test(String(err.message))) {
+      const delay = attempt * 2000;
+      console.warn(`  retry ${entry.category}/${entry.id} after ${delay}ms (${err.message.slice(0, 120)})`);
+      await new Promise((r) => setTimeout(r, delay));
+      return generateOne(apiKey, model, entry, attempt + 1);
+    }
+    throw err;
+  }
+}
+
+async function main() {
+  const entries = selectEntries();
+  console.log(`selected ${entries.length}/${MANIFEST.length} manifest entries`);
+
+  if (dryRun) {
+    for (const e of entries) {
+      console.log(`[dry-run] ${e.category}/${e.id}.webp (${e.width}x${e.height})\n  prompt: ${e.prompt}`);
+    }
+    return;
+  }
+
+  const apiKey = process.env.GEMINI_API_KEY;
+  if (!apiKey) {
+    console.error("missing GEMINI_API_KEY env var. Usage: GEMINI_API_KEY=xxx node generate.mjs");
+    process.exitCode = 1;
+    return;
+  }
+
+  const models = await listModels(apiKey);
+  const model = pickModel(models);
+  console.log(`using model: ${model.name} (${model.kind})`);
+
+  const failures = [];
+  for (const entry of entries) {
+    const outDir = path.join(OUT_ROOT, entry.category);
+    const outPath = path.join(outDir, `${entry.id}.webp`);
+    try {
+      console.log(`generating ${entry.category}/${entry.id} ...`);
+      const raw = await generateOne(apiKey, model, entry);
+      const webp = await sharp(raw)
+        .resize(entry.width, entry.height, { fit: "cover" })
+        .webp({ quality: 88 })
+        .toBuffer();
+      await mkdir(outDir, { recursive: true });
+      await writeFile(outPath, webp);
+      console.log(`  wrote ${path.relative(OUT_ROOT, outPath)}`);
+      await new Promise((r) => setTimeout(r, 1500)); // 溫和節流，避免打爆 rate limit
+    } catch (err) {
+      console.error(`  FAILED ${entry.category}/${entry.id}: ${err.message}`);
+      failures.push(entry);
+    }
+  }
+
+  if (failures.length > 0) {
+    console.error(`\n${failures.length} entries failed: ${failures.map((f) => `${f.category}/${f.id}`).join(", ")}`);
+    process.exitCode = 1;
+  } else {
+    console.log(`\nall ${entries.length} entries generated.`);
+  }
+}
+
+main();

--- a/azure-voyage/tools/artgen/manifest.mjs
+++ b/azure-voyage/tools/artgen/manifest.mjs
@@ -1,0 +1,94 @@
+/**
+ * M16 P0 生圖訂單表（docs/11 §2/§4）：每筆對應 `apps/web/public/art/<category>/<id>.webp`。
+ * 風格方向 A（古典油畫×羊皮紙），prompt 由 content 資料展開，不含 KOEI／大航海時代等字樣。
+ */
+
+export const STYLE_PREFIX =
+  "classical oil painting, age of sail era, warm candlelight palette, " +
+  "consistent painterly style, game asset, clean composition, " +
+  "no text, no watermark, no signature";
+
+export const NEGATIVE_PROMPT =
+  "modern objects, photograph, real person, text, watermark, frame, border, low quality";
+
+// ── A. 港口場景（7 海域代表圖，size=2；size 1/3 港口沿用同張，缺檔則走 M13 剪影 fallback）──
+const PORT_SCENES = [
+  {
+    regionId: "north_reach",
+    words: "snow-dusted timber roofs, cold windswept fjord harbor, grey stone piers, pine-covered hills",
+  },
+  {
+    regionId: "amber_gulf",
+    words: "golden sandstone buildings, calm turquoise gulf waters, olive groves on the hillside",
+  },
+  {
+    regionId: "ironcliff",
+    words: "dark iron-hued cliffs, rugged coastline, weathered granite piers, forge smoke over rooftops",
+  },
+  {
+    regionId: "silkwind",
+    words: "terraced silk-trade town, colorful silk banners, narrow strait with lantern-lit junks",
+  },
+  {
+    regionId: "meridian",
+    words: "bustling equatorial crossroads harbor, spice warehouses, distant storm clouds on the horizon",
+  },
+  {
+    regionId: "coral_arc",
+    words: "coral reef lagoon, white sand beaches, turquoise shallows, thatched-roof stilt houses",
+  },
+  {
+    regionId: "dusk_expanse",
+    words: "twilight sky with deep crimson clouds, remote windswept outpost, black volcanic rock shoreline",
+  },
+].map(({ regionId, words }) => ({
+  category: "port-scene",
+  id: `${regionId}-s2`,
+  width: 1600,
+  height: 900,
+  prompt: `${STYLE_PREFIX}, wide establishing shot of a mid-sized harbor town, sailing ships at anchor, stone piers, ${words}`,
+}));
+
+// ── B. 航海士立繪（12 名，特徵詞取自 officersPool.ts 的技能／數值傾向）──
+const OFFICER_PORTRAITS = [
+  { id: "sera", words: "young female ship's navigator, calm intelligent gaze, star charts nearby, scholarly air" },
+  { id: "bram", words: "gruff middle-aged male gunner, weathered face, broad shoulders, confident stance" },
+  { id: "nerissa", words: "sharp-eyed female trade officer, shrewd knowing smile, fine merchant coat" },
+  { id: "tovan", words: "lean young male lookout, alert eyes, wind-tousled hair, rope-worn hands" },
+  { id: "ismay", words: "elegant multilingual female diplomat-officer, refined posture, calm composed expression" },
+  { id: "darrok", words: "scarred battle-hardened male swordsman, intense stare, cutlass at his side" },
+  { id: "lyra", words: "gentle female ship's healer, thoughtful expression, herb pouch at her belt" },
+  { id: "garvin", words: "sturdy male shipwright officer, calloused hands, practical no-nonsense demeanor" },
+  { id: "ophira", words: "commanding older female captain-officer, regal bearing, gold-trimmed coat" },
+  { id: "kesh", words: "weathered male cartographer-scout, squinting toward the horizon, rolled charts in hand" },
+  { id: "fenna", words: "meticulous female purser, sharp focus, ledger and quill in hand" },
+  { id: "rudger", words: "bold young male swordsman-officer, fierce determined look, dueling scar on cheek" },
+].map(({ id, words }) => ({
+  category: "portrait",
+  id,
+  width: 768,
+  height: 1024,
+  prompt: `${STYLE_PREFIX}, half-body portrait of a ${words}, dark plain background`,
+}));
+
+// ── E. 船級側視圖（10 級，descriptor 取自 shipClasses.ts 的定位）──
+const SHIP_VIEWS = [
+  { id: "ship.lugger", words: "small light lugger-rigged fishing boat, single mast, modest sails" },
+  { id: "ship.sloop", words: "single-masted sloop, fast and nimble, taut rigging" },
+  { id: "ship.coaster", words: "sturdy broad-beamed coastal trading vessel, low freeboard" },
+  { id: "ship.schooner", words: "two-masted schooner, fore-and-aft rigged, sleek hull" },
+  { id: "ship.brigantine", words: "two-masted brigantine, square-rigged foremast, rows of gun ports" },
+  { id: "ship.merchantman", words: "large three-masted merchantman, deep cargo hold" },
+  { id: "ship.corvette", words: "agile armed corvette, many cannon ports, raked masts" },
+  { id: "ship.frigate", words: "proud three-masted frigate, tiered gun decks, battle ensign" },
+  { id: "ship.galleon", words: "grand ocean-going galleon, towering stern castle, ornate carved transom" },
+  { id: "ship.ship_of_line", words: "massive multi-deck ship of the line, imposing rows of cannon, flagship presence" },
+].map(({ id, words }) => ({
+  category: "ship",
+  id: id.replace(/^ship\./, ""),
+  width: 1024,
+  height: 768,
+  prompt: `${STYLE_PREFIX}, side view of a ${words}, full sails, calm sea, horizon composition`,
+}));
+
+export const MANIFEST = [...PORT_SCENES, ...OFFICER_PORTRAITS, ...SHIP_VIEWS];

--- a/azure-voyage/tools/artgen/package.json
+++ b/azure-voyage/tools/artgen/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@azure-voyage/artgen",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "generate": "node generate.mjs",
+    "dry-run": "node generate.mjs --dry-run"
+  },
+  "dependencies": {
+    "sharp": "^0.33.5"
+  }
+}


### PR DESCRIPTION
## Summary
- 新增 `tools/artgen`：P0 生圖訂單表（`manifest.mjs`，29 張：7 海域港口場景、12 名航海士立繪、10 種船級側視圖），全採風格方向 A（古典油畫×羊皮紙），prompt 由現有 content 資料（`regions.ts` / `officersPool.ts` / `shipClasses.ts`）展開，不含任何 KOEI／大航海時代字樣
- `generate.mjs` 呼叫 Google Generative Language API，動態探測可用模型（Imagen `:predict` 或 Gemini `:generateContent`），輸出縮放後的 webp 到 `apps/web/public/art/<category>/<id>.webp`；API key 只吃 `GEMINI_API_KEY` 環境變數，不落地任何檔案
- `pnpm-workspace.yaml` 加入 `tools/*`，`tools/artgen/package.json` 直接依賴 `sharp`
- 把 `<GameArt category="ship">` 接進 `TavernShipyardPanel`（艦隊船清單＋建造選單船級預覽），缺圖時走 ⚓ 佔位圖示 fallback，補上 M15 資產管線裡唯一還沒有整合點的類別

本 PR 只含管線程式碼，尚未跑實際生圖（等使用者提供 Gemini API key 後另行執行、把產出的 webp 併入下一個 PR）。

## Test plan
- [x] `pnpm --filter @azure-voyage/shared test`（136 tests）全綠
- [x] `pnpm --filter web exec tsc --noEmit` 無錯誤
- [x] `pnpm --filter web build` 成功
- [x] `node tools/artgen/generate.mjs --dry-run` 確認 29 筆 prompt 正確展開
- [x] Playwright 冒煙測試：造船廠面板船縮圖 fallback（⚓）正確渲染，無 JS 例外

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013kDwmPmYtbENLcfMzDdnNF)_