### PR TITLE
fix(artgen): 移除已棄用的 Imagen negativePrompt 參數，優先選用 Gemini 圖片模型

### DIFF
--- a/azure-voyage/tools/artgen/generate.mjs
+++ b/azure-voyage/tools/artgen/generate.mjs
@@ -41,28 +41,47 @@ async function listModels(apiKey) {
   return body.models ?? [];
 }
 
-/** 動態挑模型：優先 Imagen（:predict），其次支援圖片輸出的 Gemini（:generateContent）。 */
+/**
+ * 動態挑模型：優先支援圖片輸出的 Gemini（:generateContent）——Imagen 的 :predict
+ * 目前只開放付費方案（實測 HTTP 400 "Imagen 3 is only available on paid plans"），
+ * 免費 API key 一律走不到。非 preview 的穩定型號優先，避免 preview 配額/穩定性問題。
+ */
 function pickModel(models) {
-  const imagen = models.find(
-    (m) => /imagen/i.test(m.name) && (m.supportedGenerationMethods ?? []).includes("predict"),
-  );
-  if (imagen) return { name: imagen.name, kind: "imagen" };
+  const byName = (name) => models.find((m) => m.name === `models/${name}`);
+  const preferredGemini = [
+    "gemini-2.5-flash-image",
+    "gemini-3.1-flash-lite-image",
+    "gemini-3-pro-image",
+    "gemini-3.1-flash-image",
+  ];
+  for (const name of preferredGemini) {
+    const m = byName(name);
+    if (m) return { name: m.name, kind: "gemini" };
+  }
 
   const geminiImage = models.find(
     (m) => /image/i.test(m.name) && (m.supportedGenerationMethods ?? []).includes("generateContent"),
   );
   if (geminiImage) return { name: geminiImage.name, kind: "gemini" };
 
+  const imagen = models.find(
+    (m) => /imagen/i.test(m.name) && (m.supportedGenerationMethods ?? []).includes("predict"),
+  );
+  if (imagen) return { name: imagen.name, kind: "imagen" };
+
   throw new Error("no image-capable model found in this API key's model list");
 }
 
 async function callImagen(apiKey, modelName, prompt) {
+  // 注意：目前 Imagen 版本已不接受 parameters.negativePrompt（HTTP 400
+  // INVALID_ARGUMENT: "Setting negativePrompt is no longer supported."）——
+  // 改把負面提示併進 prompt 文字本身，跟 Gemini 路徑一致的做法。
   const res = await fetch(`${API_BASE}/${modelName}:predict?key=${apiKey}`, {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({
-      instances: [{ prompt }],
-      parameters: { sampleCount: 1, negativePrompt: NEGATIVE_PROMPT },
+      instances: [{ prompt: `${prompt}. Avoid: ${NEGATIVE_PROMPT}.` }],
+      parameters: { sampleCount: 1 },
     }),
   });
   if (!res.ok) throw new Error(`imagen predict failed: HTTP ${res.status} ${await res.text()}`);


### PR DESCRIPTION
## Summary
- Google Imagen 的 `:predict` 端點已不再接受 `parameters.negativePrompt`（實測回 `HTTP 400 INVALID_ARGUMENT: "Setting negativePrompt is no longer supported."`）——改把負面提示併入 prompt 文字本身，跟既有 Gemini `:generateContent` 路徑做法一致
- `pickModel` 改成優先挑選原生支援圖片輸出的 Gemini 模型，Imagen 的 `:predict` 目前只開放付費方案（實測 `HTTP 400 "Imagen 3 is only available on paid plans"`），免費 API key 一律呼叫不到，故調整優先序並優先選非 preview 的穩定型號

在實際用使用者提供的 Gemini API key 測試時發現並修正上述兩個問題；目前確認該 key 所屬專案的圖片類模型（Imagen 與所有 Gemini 原生圖片模型）免費額度皆為 0（`limit: 0`），需要專案啟用計費才能實際產圖——這是帳號層級限制，不是程式問題。

## Test plan
- [x] `node tools/artgen/generate.mjs --dry-run` 確認 manifest 展開不受影響
- [x] 實測呼叫 API：確認 negativePrompt 400 錯誤消失，改為收到帳號額度層級的 429（非程式錯誤）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013kDwmPmYtbENLcfMzDdnNF)_