### PR TITLE
feat(artgen): 新增 Pollinations.ai 生圖腳本（本機執行用）

### DIFF
--- a/azure-voyage/tools/artgen/README.md
+++ b/azure-voyage/tools/artgen/README.md
@@ -1,10 +1,15 @@
 # tools/artgen
 
-M16 生圖管線（docs/11 §3 API 模式）。讀 `manifest.mjs` 的訂單表，呼叫 Google
-Generative Language API（Gemini / Imagen，動態探測可用模型），輸出 webp 到
-`apps/web/public/art/<category>/<id>.webp`，命名對應 `GameArt` 元件的資產 key。
+M16 生圖管線（docs/11 §3 API 模式）。讀 `manifest.mjs` 的訂單表，兩支腳本共用同一份
+29 筆 P0 prompt，差別只在打哪個生圖服務：
 
-## 使用方式
+- `generate.mjs` → Google Generative Language API（Gemini / Imagen）
+- `generate-pollinations.mjs` → Pollinations.ai
+
+輸出都是 webp，寫到 `apps/web/public/art/<category>/<id>.webp`，命名對應 `GameArt`
+元件的資產 key。
+
+## Gemini / Imagen（`generate.mjs`）
 
 ```bash
 cd tools/artgen
@@ -21,10 +26,36 @@ GEMINI_API_KEY=xxx node generate.mjs --only=ship
 GEMINI_API_KEY=xxx node generate.mjs --id=sera
 ```
 
+注意：Imagen 的 `:predict` 目前只開放付費方案；免費 API key 的 Google Cloud 專案
+如果沒開計費，所有圖片模型（含原生 Gemini 圖片輸出模型）配額都是 0，會收到
+`RESOURCE_EXHAUSTED`。需要專案啟用計費才能真的產圖。
+
+## Pollinations.ai（`generate-pollinations.mjs`）
+
+⚠️ **這支必須在你自己的機器上跑**，不能在 Claude 執行的 sandbox 裡跑——sandbox
+的網路政策直接擋掉 `pollinations.ai`（proxy 在 CONNECT 階段就回 403，不是 key
+或程式的問題）。用法一樣：
+
+```bash
+cd tools/artgen
+pnpm install
+POLLINATIONS_API_KEY=xxx node generate-pollinations.mjs --dry-run
+POLLINATIONS_API_KEY=xxx node generate-pollinations.mjs
+POLLINATIONS_API_KEY=xxx node generate-pollinations.mjs --only=ship
+```
+
+跑完後 `apps/web/public/art/` 底下會多出對應的 webp 檔，直接 commit/push 回來，
+或把整個資料夾傳回來給我整理入庫都可以。
+
+Pollinations 認證機制若跟目前版本兜不起來（他們近期調整過幾次），去
+https://pollinations.ai 的官方文件確認目前正確的認證參數，再調整
+`callPollinations()` 裡送出的 header/query 參數。
+
 ## 安全性
 
 - **絕對不要**把 API key 寫進 `.env`、程式碼、commit message 或任何會被 `git add`
-  的檔案。此腳本只從 `process.env.GEMINI_API_KEY` 讀取，用完即丟。
+  的檔案。兩支腳本都只從環境變數讀取（`GEMINI_API_KEY` / `POLLINATIONS_API_KEY`），
+  用完即丟。
 - 產生的圖片本身沒有秘密資訊，可以正常 commit 進 `apps/web/public/art/`。
 
 ## 缺圖不擋玩

--- a/azure-voyage/tools/artgen/generate-pollinations.mjs
+++ b/azure-voyage/tools/artgen/generate-pollinations.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+/**
+ * M16 生圖管線（Pollinations.ai 備援路徑）：跟 generate.mjs 共用同一份
+ * manifest.mjs 訂單表，但改打 Pollinations 的圖片 API。
+ *
+ * ⚠️ 這支腳本必須在「本機」（不是這個 sandbox）執行——sandbox 的網路政策
+ * 直接擋掉 pollinations.ai（proxy CONNECT 就回 403），不是程式或 key 的問題。
+ *
+ * 用法（在你自己的機器上，clone 這個 repo 之後）：
+ *   cd tools/artgen
+ *   pnpm install                     # 裝 sharp（webp 轉檔用）
+ *   POLLINATIONS_API_KEY=xxx node generate-pollinations.mjs --dry-run
+ *   POLLINATIONS_API_KEY=xxx node generate-pollinations.mjs
+ *   POLLINATIONS_API_KEY=xxx node generate-pollinations.mjs --only=ship
+ *   POLLINATIONS_API_KEY=xxx node generate-pollinations.mjs --id=sera
+ *
+ * 產出直接寫進 ../../apps/web/public/art/<category>/<id>.webp（相對這支腳本的
+ * 位置算），跑完把整個 apps/web/public/art/ 目錄的變更 commit/push 回來，
+ * 或直接把資料夾傳回來給我整理入庫都可以。
+ */
+
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import sharp from "sharp";
+import { MANIFEST } from "./manifest.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_ROOT = path.resolve(__dirname, "../../apps/web/public/art");
+const API_BASE = "https://image.pollinations.ai/prompt";
+
+const args = process.argv.slice(2);
+const dryRun = args.includes("--dry-run");
+const onlyCategory = args.find((a) => a.startsWith("--only="))?.slice("--only=".length);
+const onlyId = args.find((a) => a.startsWith("--id="))?.slice("--id=".length);
+
+function selectEntries() {
+  return MANIFEST.filter((e) => (!onlyCategory || e.category === onlyCategory) && (!onlyId || e.id === onlyId));
+}
+
+/**
+ * Pollinations 的圖片端點是 GET /prompt/<url-encoded prompt>，直接回傳圖片 bytes。
+ * 認證機制官方文件近期有變動過，這裡兩種都送，兼容兩種版本：
+ *   1. Authorization: Bearer <key> header
+ *   2. ?token=<key> query 參數
+ * 如果兩種都失效，去 https://pollinations.ai 官方文件確認當前正確的認證方式。
+ */
+async function callPollinations(apiKey, entry, attempt = 1) {
+  const url = new URL(`${API_BASE}/${encodeURIComponent(entry.prompt)}`);
+  url.searchParams.set("width", String(entry.width));
+  url.searchParams.set("height", String(entry.height));
+  url.searchParams.set("nologo", "true");
+  url.searchParams.set("model", "flux");
+  url.searchParams.set("seed", String(hashSeed(entry.category + entry.id)));
+  url.searchParams.set("token", apiKey);
+
+  const res = await fetch(url, {
+    headers: { authorization: `Bearer ${apiKey}` },
+  });
+
+  if (!res.ok) {
+    const bodyText = await res.text().catch(() => "");
+    const msg = `pollinations request failed: HTTP ${res.status} ${bodyText.slice(0, 300)}`;
+    if (attempt < 3 && /HTTP (429|5\d\d)/.test(msg)) {
+      const delay = attempt * 2000;
+      console.warn(`  retry ${entry.category}/${entry.id} after ${delay}ms (${msg.slice(0, 120)})`);
+      await new Promise((r) => setTimeout(r, delay));
+      return callPollinations(apiKey, entry, attempt + 1);
+    }
+    throw new Error(msg);
+  }
+
+  const arrayBuffer = await res.arrayBuffer();
+  return Buffer.from(arrayBuffer);
+}
+
+/** 確定性 seed：同一筆資產每次重跑都拿到同構圖，方便重試/校對。 */
+function hashSeed(str) {
+  let h = 0;
+  for (let i = 0; i < str.length; i++) {
+    h = (Math.imul(31, h) + str.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h) % 1_000_000;
+}
+
+async function main() {
+  const entries = selectEntries();
+  console.log(`selected ${entries.length}/${MANIFEST.length} manifest entries`);
+
+  if (dryRun) {
+    for (const e of entries) {
+      console.log(`[dry-run] ${e.category}/${e.id}.webp (${e.width}x${e.height})\n  prompt: ${e.prompt}`);
+    }
+    return;
+  }
+
+  const apiKey = process.env.POLLINATIONS_API_KEY;
+  if (!apiKey) {
+    console.error("missing POLLINATIONS_API_KEY env var. Usage: POLLINATIONS_API_KEY=xxx node generate-pollinations.mjs");
+    process.exitCode = 1;
+    return;
+  }
+
+  const failures = [];
+  for (const entry of entries) {
+    const outDir = path.join(OUT_ROOT, entry.category);
+    const outPath = path.join(outDir, `${entry.id}.webp`);
+    try {
+      console.log(`generating ${entry.category}/${entry.id} ...`);
+      const raw = await callPollinations(apiKey, entry);
+      const webp = await sharp(raw)
+        .resize(entry.width, entry.height, { fit: "cover" })
+        .webp({ quality: 88 })
+        .toBuffer();
+      await mkdir(outDir, { recursive: true });
+      await writeFile(outPath, webp);
+      console.log(`  wrote ${path.relative(OUT_ROOT, outPath)}`);
+      await new Promise((r) => setTimeout(r, 1000)); // 溫和節流
+    } catch (err) {
+      console.error(`  FAILED ${entry.category}/${entry.id}: ${err.message}`);
+      failures.push(entry);
+    }
+  }
+
+  if (failures.length > 0) {
+    console.error(`\n${failures.length} entries failed: ${failures.map((f) => `${f.category}/${f.id}`).join(", ")}`);
+    process.exitCode = 1;
+  } else {
+    console.log(`\nall ${entries.length} entries generated.`);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- 新增 `tools/artgen/generate-pollinations.mjs`：共用既有 `manifest.mjs` 的 29 筆 P0 prompt，改打 Pollinations.ai 的圖片端點，輸出格式/命名/webp 轉檔邏輯與 `generate.mjs` 一致
- 起因：這個 sandbox 的網路政策直接擋掉 `pollinations.ai`（proxy 在 CONNECT 階段就回 403），沒辦法在這裡直接呼叫；這支腳本設計成給使用者在自己機器上跑，跑完把 `apps/web/public/art/` 的產出傳回來整理入庫
- 更新 `tools/artgen/README.md`，補上兩條生圖路徑（Gemini/Imagen vs Pollinations）的使用說明與各自的已知限制

## Test plan
- [x] `node --check tools/artgen/generate-pollinations.mjs` 語法檢查通過
- [x] `node generate-pollinations.mjs --dry-run --id=sera` 確認 prompt 展開正確（未實際打網路）
- 無法在此環境驗證實際生圖（pollinations.ai 網路被擋），需使用者本機驗證

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013kDwmPmYtbENLcfMzDdnNF)_