### PR TITLE
M17: 補完批次美術整合（標題視覺/戰鬥背景/會長立繪/事件插圖/商品圖示）

### DIFF
--- a/azure-voyage/apps/web/src/app/(auth)/layout.tsx
+++ b/azure-voyage/apps/web/src/app/(auth)/layout.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from "react";
+import { GameArt } from "@/game/GameArt";
+
+/** 登入/註冊頁共用主視覺（M17；docs/11 §2 F）：缺圖時走漸層裝飾 fallback，不擋玩。 */
+export default function AuthLayout({ children }: { children: ReactNode }) {
+  return (
+    <div>
+      <div className="relative mx-auto mt-8 h-40 w-full max-w-3xl overflow-hidden rounded-lg border border-gold/30 sm:h-56">
+        <GameArt
+          category="key-visual"
+          id="title"
+          alt="蒼瀾航路"
+          className="h-full w-full object-cover"
+          fallback={
+            <div
+              className="h-full w-full"
+              style={{
+                background:
+                  "radial-gradient(ellipse at 30% -10%, rgba(217,164,65,0.25), transparent 55%), " +
+                  "linear-gradient(160deg, #12283f, #08111f 70%)",
+              }}
+            />
+          }
+        />
+        <div className="absolute inset-0 bg-gradient-to-t from-abyss/90 via-transparent to-transparent" />
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/azure-voyage/apps/web/src/app/play/[worldId]/page.tsx
+++ b/azure-voyage/apps/web/src/app/play/[worldId]/page.tsx
@@ -43,6 +43,7 @@ import { ExplorationPanel } from "@/game/ExplorationPanel";
 import { DiscoveryPanel } from "@/game/DiscoveryPanel";
 import { InfluencePanel } from "@/game/InfluencePanel";
 import { PortCutscene, type CutsceneState } from "@/game/PortCutscene";
+import { GameArt } from "@/game/GameArt";
 import { PortBanner } from "@/game/PortBanner";
 
 /** M13：使用者選過「不再顯示這個動畫」後永久跳過過場（不影響其他玩家/裝置） */
@@ -104,6 +105,8 @@ export default function PlayPage() {
   const [pendingHeading, setPendingHeading] = useState<number | null>(null);
   const [speedIdx, setSpeedIdx] = useState(1);
   const [notice, setNotice] = useState<string | null>(null);
+  /** 世界事件插圖（M17；docs/11 §2 H），只有 STORM/FESTIVAL/RUMOR 三種世界事件才有對應插圖 */
+  const [noticeKind, setNoticeKind] = useState<"storm" | "festival" | "rumor" | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [battleId, setBattleId] = useState<string | null>(null);
   const [battleState, setBattleState] = useState<BattleStateView | null>(null);
@@ -162,7 +165,10 @@ export default function PlayPage() {
         latestFleetRef.current = mine;
         if (mine.activity === "DOCKED" || mine.activity === "ANCHORED") setRoute(null);
       }
-      if (payload.notices.length > 0) setNotice(payload.notices.join(" "));
+      if (payload.notices.length > 0) {
+        setNotice(payload.notices.join(" "));
+        setNoticeKind(null);
+      }
       // tick 有成功推進，「世界正在推進中」這類瞬時壅塞錯誤即已過期，自動清掉
       setError((prev) => (prev === ERROR_MESSAGES_ZH_TW.WORLD_BUSY ? null : prev));
     });
@@ -182,6 +188,7 @@ export default function PlayPage() {
       tripEventCountRef.current = 0;
       if (cutscenesSkipped()) {
         setNotice(`艦隊已抵達 ${portById(payload.portId).name}`);
+        setNoticeKind(null);
       } else {
         setCutscene({ kind: "arrival", portId: payload.portId, day: payload.tick, summary });
       }
@@ -196,6 +203,11 @@ export default function PlayPage() {
         setStormFlashTrigger((n) => n + 1);
       }
       setNotice(payload.event.narrative);
+      setNoticeKind(
+        payload.event.type === "STORM" || payload.event.type === "FESTIVAL" || payload.event.type === "RUMOR"
+          ? (payload.event.type.toLowerCase() as "storm" | "festival" | "rumor")
+          : null,
+      );
       api.getWorld(worldId).then(setSnapshot).catch(() => undefined);
     });
     socket.on(WS_EVENTS.SERVER_BATTLE_START, (payload: ServerBattleStartPayload) => {
@@ -215,6 +227,7 @@ export default function PlayPage() {
             ? "成功脫離戰場。"
             : "艦隊戰敗，被拖回母港療傷……",
       );
+      setNoticeKind(null);
       setBattleId(null);
       setBattleState(null);
       api.getWorld(worldId).then(setSnapshot).catch(() => undefined);
@@ -332,6 +345,7 @@ export default function PlayPage() {
       if (activity === "ANCHORED") {
         seedFleetActivity("SAILING");
         setNotice(null);
+        setNoticeKind(null);
       }
     } catch (err) {
       setError(err instanceof ApiError ? err.message : "設定航線失敗");
@@ -403,6 +417,7 @@ export default function PlayPage() {
       if (outcome === "already") await api.anchor(worldId, fleet.id);
       seedFleetActivity("SAILING");
       setNotice(null);
+      setNoticeKind(null);
     } catch (err) {
       setError(err instanceof ApiError ? err.message : "操作失敗");
     }
@@ -550,7 +565,20 @@ export default function PlayPage() {
       </header>
 
       {error && <p className="text-sm text-red-400">{error}</p>}
-      {notice && <p className="text-sm text-emerald-300">{notice}</p>}
+      {notice && (
+        <p className="flex items-center gap-2 text-sm text-emerald-300">
+          {noticeKind && (
+            <GameArt
+              category="event"
+              id={noticeKind}
+              alt=""
+              className="h-8 w-8 shrink-0 rounded border border-gold/40 object-cover"
+              fallback={<></>}
+            />
+          )}
+          {notice}
+        </p>
+      )}
 
       {gameEnded && (
         <section className="panel border-2 border-gold bg-gold/10 text-center">
@@ -767,6 +795,8 @@ export default function PlayPage() {
           battleId={battleId}
           state={battleState}
           log={battleLog}
+          weather={weather}
+          tick={tick ?? undefined}
         />
       )}
 

--- a/azure-voyage/apps/web/src/game/BattleScene.tsx
+++ b/azure-voyage/apps/web/src/game/BattleScene.tsx
@@ -2,13 +2,23 @@
 
 import { useState } from "react";
 import type { Socket } from "socket.io-client";
-import { WS_EVENTS, type BattleActionInput, type BattleStateView } from "@azure-voyage/shared";
+import { WS_EVENTS, type BattleActionInput, type BattleStateView, type WeatherKind } from "@azure-voyage/shared";
+import { GameArt } from "./GameArt";
 
 interface Props {
   socket: Socket;
   battleId: string;
   state: BattleStateView;
   log: string[];
+  /** 交戰當下的天氣/時刻，決定背景（M17；docs/11 §2 G）；缺就走平靜海。 */
+  weather?: WeatherKind | null;
+  tick?: number;
+}
+
+/** 沒有晝夜系統，用 tick 奇偶當「夜戰」的簡單決定性判斷；風暴醞釀則優先顯示暴風海。 */
+function pickBattleBg(weather?: WeatherKind | null, tick?: number): "calm" | "storm" | "night" {
+  if (weather === "STORM_BREWING") return "storm";
+  return (tick ?? 0) % 2 === 0 ? "calm" : "night";
 }
 
 const ACTION_LABELS: Record<BattleActionInput["type"], string> = {
@@ -20,7 +30,8 @@ const ACTION_LABELS: Record<BattleActionInput["type"], string> = {
 };
 
 /** 海戰場景（M5 簡化版：清單式棋盤，非完整 Pixi 六角board，見 docs/07 待補）。 */
-export function BattleScene({ socket, battleId, state, log }: Props) {
+export function BattleScene({ socket, battleId, state, log, weather, tick }: Props) {
+  const battleBg = pickBattleBg(weather, tick);
   const [selectedUnitId, setSelectedUnitId] = useState<string | null>(
     state.pendingUnitIds.find((id) => state.units.find((u) => u.id === id)?.side === "PLAYER") ?? null,
   );
@@ -77,8 +88,22 @@ export function BattleScene({ socket, battleId, state, log }: Props) {
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4">
-      <div className="panel max-h-[90vh] w-full max-w-3xl space-y-4 overflow-y-auto">
-        <h2 className="text-xl font-bold text-foam">
+      <GameArt
+        category="battle-bg"
+        id={battleBg}
+        alt=""
+        className="pointer-events-none fixed inset-0 h-full w-full object-cover opacity-30"
+        fallback={<></>}
+      />
+      <div className="panel relative max-h-[90vh] w-full max-w-3xl space-y-4 overflow-y-auto">
+        <h2 className="flex items-center gap-2 text-xl font-bold text-foam">
+          <GameArt
+            category="event"
+            id="pirate"
+            alt=""
+            className="h-8 w-8 rounded border border-gold/40 object-cover"
+            fallback={<span className="text-2xl">☠️</span>}
+          />
           海戰進行中 · 第 {state.round} 回合，正在行動：
           {state.units.find((u) => u.id === state.pendingUnitIds[0])?.name ?? "—"}
         </h2>

--- a/azure-voyage/apps/web/src/game/ExplorationPanel.tsx
+++ b/azure-voyage/apps/web/src/game/ExplorationPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { api, ApiError } from "@/lib/api";
+import { GameArt } from "./GameArt";
 
 interface Props {
   worldId: string;
@@ -14,12 +15,19 @@ interface Props {
 export function ExplorationPanel({ worldId, fleetId, activity, onChanged }: Props) {
   const [busy, setBusy] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
+  /** 事件插圖（M17；docs/11 §2 H）：下錨＝anchor，探索成功＝discovery */
+  const [messageKind, setMessageKind] = useState<"anchor" | "discovery" | null>(null);
 
   async function toggleAnchor() {
     setBusy(true);
     setMessage(null);
+    setMessageKind(null);
     try {
       await api.anchor(worldId, fleetId);
+      if (activity !== "ANCHORED") {
+        setMessage("已下錨，可以開始探索周邊海域。");
+        setMessageKind("anchor");
+      }
       onChanged();
     } catch (err) {
       setMessage(err instanceof ApiError ? err.message : "操作失敗");
@@ -31,9 +39,11 @@ export function ExplorationPanel({ worldId, fleetId, activity, onChanged }: Prop
   async function explore() {
     setBusy(true);
     setMessage(null);
+    setMessageKind(null);
     try {
       const result = await api.explore(worldId, fleetId);
       setMessage(result.narrative);
+      if (result.success) setMessageKind("discovery");
       onChanged();
     } catch (err) {
       setMessage(err instanceof ApiError ? err.message : "探索失敗");
@@ -54,7 +64,20 @@ export function ExplorationPanel({ worldId, fleetId, activity, onChanged }: Prop
           探索周邊海域
         </button>
       )}
-      {message && <span className="text-sm text-amber-300">{message}</span>}
+      {message && (
+        <span className="flex items-center gap-2 text-sm text-amber-300">
+          {messageKind && (
+            <GameArt
+              category="event"
+              id={messageKind}
+              alt=""
+              className="h-8 w-8 shrink-0 rounded border border-gold/40 object-cover"
+              fallback={<></>}
+            />
+          )}
+          {message}
+        </span>
+      )}
     </div>
   );
 }

--- a/azure-voyage/apps/web/src/game/GameArt.tsx
+++ b/azure-voyage/apps/web/src/game/GameArt.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 
 /**
  * 資產管線的前端端點（docs/11 §3）：嘗試載入 `public/art/<category>/<id>.webp`，
@@ -22,12 +22,26 @@ export interface GameArtProps {
 export function GameArt({ category, id, alt, className, fallback }: GameArtProps) {
   const key = `${category}/${id}`;
   const [failed, setFailed] = useState(missing.has(key));
+  const imgRef = useRef<HTMLImageElement>(null);
+
+  // 靜態預渲染頁（如登入/註冊）在瀏覽器解析 HTML 當下就會開始載入 <img>，
+  // 缺圖 404 常常在 React hydrate、掛上 onError 監聽器之前就已經觸發完畢，
+  // 導致原生 error 事件被錯過。掛載後主動檢查 img.complete + naturalWidth
+  // 補上這個 race condition 的判斷，而不是只依賴 onError。
+  useEffect(() => {
+    const img = imgRef.current;
+    if (img && img.complete && img.naturalWidth === 0) {
+      missing.add(key);
+      setFailed(true);
+    }
+  }, [key]);
 
   if (failed) return <>{fallback}</>;
   return (
     // 一般 <img>（而非 next/image）：資產是可缺席的靜態檔案，需要 onError fallback
     // 語意，且不想為每張圖配置 next/image 的尺寸最佳化管線。
     <img
+      ref={imgRef}
       src={`/art/${key}.webp`}
       alt={alt}
       className={className}

--- a/azure-voyage/apps/web/src/game/InfluencePanel.tsx
+++ b/azure-voyage/apps/web/src/game/InfluencePanel.tsx
@@ -1,13 +1,21 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { NPC_GUILD_TEMPLATES } from "@azure-voyage/shared";
 import { api, ApiError } from "@/lib/api";
+import { GameArt } from "./GameArt";
 
 interface Props {
   worldId: string;
   portId: string;
   gold: number;
   onInvested: () => void;
+}
+
+/** 商會名稱查對 NPC 模板 key，玩家自己的商會名稱是自訂的，查不到就沒有立繪（M17）。 */
+function guildArtId(guildName: string): string | null {
+  const template = NPC_GUILD_TEMPLATES.find((t) => t.name === guildName);
+  return template ? `guild-${template.key.replace(/^npc\./, "")}` : null;
 }
 
 /** 港口影響力投資面板（docs/01 §4.3；docs/05 §6）。 */
@@ -53,13 +61,31 @@ export function InfluencePanel({ worldId, portId, gold, onInvested }: Props) {
       <h3 className="text-lg font-semibold text-foam">港口影響力</h3>
       {error && <p className="text-sm text-red-400">{error}</p>}
       <ul className="space-y-1 text-sm">
-        {detail.influences.map((inf) => (
-          <li key={inf.guildId} className="flex items-center gap-2">
-            <span className="inline-block h-2.5 w-2.5 rounded-full" style={{ backgroundColor: inf.color }} />
-            <span className="flex-1 text-slate-300">{inf.guildName}</span>
-            <span className="font-mono text-gold">{inf.share.toFixed(1)}%</span>
-          </li>
-        ))}
+        {detail.influences.map((inf) => {
+          const artId = guildArtId(inf.guildName);
+          return (
+            <li key={inf.guildId} className="flex items-center gap-2">
+              {artId ? (
+                <GameArt
+                  category="portrait"
+                  id={artId}
+                  alt={inf.guildName}
+                  className="h-8 w-7 shrink-0 rounded border border-gold/40 object-cover"
+                  fallback={
+                    <span
+                      className="inline-block h-2.5 w-2.5 rounded-full"
+                      style={{ backgroundColor: inf.color }}
+                    />
+                  }
+                />
+              ) : (
+                <span className="inline-block h-2.5 w-2.5 rounded-full" style={{ backgroundColor: inf.color }} />
+              )}
+              <span className="flex-1 text-slate-300">{inf.guildName}</span>
+              <span className="font-mono text-gold">{inf.share.toFixed(1)}%</span>
+            </li>
+          );
+        })}
       </ul>
       <div className="flex items-center gap-2">
         <input

--- a/azure-voyage/apps/web/src/game/TradePanel.tsx
+++ b/azure-voyage/apps/web/src/game/TradePanel.tsx
@@ -3,6 +3,19 @@
 import { useEffect, useState } from "react";
 import { commodityById } from "@azure-voyage/shared";
 import { api, ApiError } from "@/lib/api";
+import { GameArt } from "./GameArt";
+
+/** 商品分類的 emoji fallback（缺圖示時），對應 commodities.ts 的 COMMODITY_CATEGORIES。 */
+const CATEGORY_FALLBACK_EMOJI: Record<string, string> = {
+  FOOD: "🐟",
+  DRINK: "🍷",
+  TEXTILE: "🧵",
+  ORE: "⛏️",
+  WEAPONRY: "⚔️",
+  CRAFT: "🏺",
+  LUXURY: "💎",
+  SPICE: "🌶️",
+};
 
 interface TradePanelProps {
   worldId: string;
@@ -76,9 +89,22 @@ export function TradePanel({ worldId, portId, fleetId, shipId, onTraded }: Trade
             </tr>
           </thead>
           <tbody>
-            {detail.market.map((m) => (
+            {detail.market.map((m) => {
+              const commodity = commodityById(m.commodityId);
+              return (
               <tr key={m.commodityId} className="border-t border-foam/10">
-                <td className="py-2">{commodityById(m.commodityId).name}</td>
+                <td className="py-2">
+                  <span className="flex items-center gap-2">
+                    <GameArt
+                      category="goods"
+                      id={commodity.category.toLowerCase()}
+                      alt={commodity.category}
+                      className="h-6 w-6 shrink-0 rounded object-cover"
+                      fallback={<span className="text-base">{CATEGORY_FALLBACK_EMOJI[commodity.category]}</span>}
+                    />
+                    {commodity.name}
+                  </span>
+                </td>
                 <td className="py-2 font-mono">{m.stock}</td>
                 <td className="py-2 font-mono text-emerald-300">{m.buyPrice}</td>
                 <td className="py-2 font-mono text-amber-300">{m.sellPrice}</td>
@@ -102,7 +128,8 @@ export function TradePanel({ worldId, portId, fleetId, shipId, onTraded }: Trade
                   </button>
                 </td>
               </tr>
-            ))}
+              );
+            })}
           </tbody>
         </table>
       </div>

--- a/azure-voyage/tools/artgen/manifest.mjs
+++ b/azure-voyage/tools/artgen/manifest.mjs
@@ -91,4 +91,106 @@ const SHIP_VIEWS = [
   prompt: `${STYLE_PREFIX}, side view of a ${words}, full sails, calm sea, horizon composition`,
 }));
 
-export const MANIFEST = [...PORT_SCENES, ...OFFICER_PORTRAITS, ...SHIP_VIEWS];
+// ── F. 標題／登入頁主視覺（1 張）──
+const KEY_VISUALS = [
+  {
+    id: "title",
+    words:
+      "a lone tall ship at full sail crossing sunlit open ocean under a dramatic sky, " +
+      "sense of adventure and discovery, wide cinematic composition",
+  },
+].map(({ id, words }) => ({
+  category: "key-visual",
+  id,
+  width: 1600,
+  height: 900,
+  prompt: `${STYLE_PREFIX}, grand title illustration, ${words}`,
+}));
+
+// ── G. 戰鬥背景（平靜海／風暴海／夜戰，3 張）──
+const BATTLE_BACKGROUNDS = [
+  { id: "calm", words: "calm turquoise sea battlefield, gentle waves, clear sky, ships engaged at a distance" },
+  { id: "storm", words: "stormy grey-green sea battlefield, heavy rain, lightning, tall crashing waves" },
+  { id: "night", words: "night sea battlefield under moonlight, dark deep-blue water, distant ship lanterns" },
+].map(({ id, words }) => ({
+  category: "battle-bg",
+  id,
+  width: 1600,
+  height: 900,
+  prompt: `${STYLE_PREFIX}, wide battle scene backdrop, ${words}, dramatic composition`,
+}));
+
+// ── C. NPC 商會會長立繪（5 名，特徵詞取自 npcGuilds.ts 的 archetype）──
+const GUILD_LEADER_PORTRAITS = [
+  {
+    id: "frost_compact",
+    words: "stern older guild leader in fur-lined coat, cautious calculating expression, northern harbor air",
+  },
+  {
+    id: "crimson_sails",
+    words: "roguish guild leader with crimson sash, half-smirk, dangerous confident air",
+  },
+  {
+    id: "gilded_scale",
+    words: "wealthy guild leader in fine embroidered coat, holding a balance scale, shrewd composed expression",
+  },
+  {
+    id: "silkwind_caravan",
+    words: "silk-robed guild leader with ornate turban, calm commanding presence, trade ledger in hand",
+  },
+  {
+    id: "tideglass_league",
+    words: "weathered explorer guild leader, sun-bronzed skin, spyglass in hand, adventurous confident look",
+  },
+].map(({ id, words }) => ({
+  category: "portrait",
+  id: `guild-${id}`,
+  width: 768,
+  height: 1024,
+  prompt: `${STYLE_PREFIX}, half-body portrait of a ${words}, dark plain background`,
+}));
+
+// ── H. 事件插圖（風暴/慶典/傳聞/發現/下錨探索/海賊，6 張）──
+const EVENT_ILLUSTRATIONS = [
+  { id: "storm", words: "a violent sea storm brewing, dark clouds and whitecaps, dramatic lighting" },
+  { id: "festival", words: "a harbor festival at night, lanterns and fireworks over the water, joyful atmosphere" },
+  { id: "rumor", words: "a hooded figure whispering at a candlelit tavern table, mysterious atmosphere" },
+  { id: "discovery", words: "an ancient shipwreck glimpsed underwater near a reef, sense of wonder" },
+  { id: "anchor", words: "a ship's anchor dropping into calm turquoise water, sunlight rays" },
+  { id: "pirate", words: "a pirate ship's black flag and cutlass silhouette against a stormy horizon" },
+].map(({ id, words }) => ({
+  category: "event",
+  id,
+  width: 512,
+  height: 512,
+  prompt: `${STYLE_PREFIX}, small narrative illustration of ${words}`,
+}));
+
+// ── I. 商品類別圖示（8 大類，取自 commodities.ts 的 COMMODITY_CATEGORIES）──
+const GOODS_ICONS = [
+  { id: "food", words: "dried fish and salt barrels, still life" },
+  { id: "drink", words: "a wine bottle and rum cask, still life" },
+  { id: "textile", words: "folded silk and wool bolts, still life" },
+  { id: "ore", words: "raw iron and copper ore chunks, still life" },
+  { id: "weaponry", words: "a cutlass and cannonball, still life" },
+  { id: "craft", words: "blown glasswork and pottery, still life" },
+  { id: "luxury", words: "pearls and amber jewelry, still life" },
+  { id: "spice", words: "peppercorns and cinnamon sticks in small sacks, still life" },
+].map(({ id, words }) => ({
+  category: "goods",
+  id,
+  width: 256,
+  height: 256,
+  prompt: `${STYLE_PREFIX}, small icon illustration of ${words}, centered composition`,
+}));
+
+export const MANIFEST = [
+  ...PORT_SCENES,
+  ...OFFICER_PORTRAITS,
+  ...SHIP_VIEWS,
+  ...KEY_VISUALS,
+  ...BATTLE_BACKGROUNDS,
+  ...GUILD_LEADER_PORTRAITS,
+  ...EVENT_ILLUSTRATIONS,
+  ...GOODS_ICONS,
+];


### PR DESCRIPTION
## Summary
- 擴充 `tools/artgen/manifest.mjs` 補上 M17 的 23 筆訂單（docs/11 §2 F/G/C/H/I）：標題主視覺 ×1、戰鬥背景（平靜/風暴/夜戰）×3、NPC 商會會長立繪 ×5、事件插圖 ×6、商品類別圖示 ×8，manifest 現有 52 筆，沿用既有風格前綴與 Pollinations 生圖管線
- 接上所有整合點（缺圖時全部走既有 fallback，不擋玩）：`(auth)` layout 標題主視覺、`BattleScene` 戰鬥背景與海賊插圖、`InfluencePanel` 會長立繪、`ExplorationPanel` 下錨/探索事件插圖、`TradePanel` 商品分類圖示、世界事件通知插圖
- 修掉 `GameArt` 一個真實 bug：靜態預渲染頁（登入/註冊）的 `<img>` 404 常在 React hydrate 掛上 `onError` 之前就已完成，原生 error 事件被錯過導致永久卡在破圖狀態；改成掛載後額外檢查 `img.complete + naturalWidth`

本 PR 只含程式碼與 manifest，尚未實際生圖（M17 這 23 張圖仍待使用者用 Pollinations key 在本機執行 `generate-pollinations.mjs` 產出後另外送出）。

## Test plan
- [x] `pnpm --filter @azure-voyage/shared test`（136 tests）全綠
- [x] `pnpm --filter web exec tsc --noEmit` 無錯誤
- [x] `pnpm --filter web build` 成功
- [x] Playwright 冒煙測試：登入/註冊主視覺 fallback、市場商品圖示 fallback、影響力面板會長立繪 fallback、下錨/探索事件插圖，皆無 JS 例外
- [x] 額外驗證修好的 GameArt race condition：登入頁截圖確認 CSS 漸層 fallback 正確顯示（先前顯示破圖圖示）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013kDwmPmYtbENLcfMzDdnNF)_