### PR TITLE
M18: 港口場景擴充到全部規模（size 1/2/3）

### DIFF
--- a/azure-voyage/tools/artgen/README.md
+++ b/azure-voyage/tools/artgen/README.md
@@ -1,7 +1,7 @@
 # tools/artgen
 
-M16 生圖管線（docs/11 §3 API 模式）。讀 `manifest.mjs` 的訂單表，兩支腳本共用同一份
-29 筆 P0 prompt，差別只在打哪個生圖服務：
+生圖管線（docs/11 §3 API 模式）。讀 `manifest.mjs` 的訂單表，兩支腳本共用同一份
+manifest（M16 P0 + M17 補完 + M18 港口規模擴充，現有 64 筆），差別只在打哪個生圖服務：
 
 - `generate.mjs` → Google Generative Language API（Gemini / Imagen）
 - `generate-pollinations.mjs` → Pollinations.ai
@@ -42,6 +42,9 @@ pnpm install
 POLLINATIONS_API_KEY=xxx node generate-pollinations.mjs --dry-run
 POLLINATIONS_API_KEY=xxx node generate-pollinations.mjs
 POLLINATIONS_API_KEY=xxx node generate-pollinations.mjs --only=ship
+
+# 只補目前缺少的檔案（例如 manifest 擴充後只想跑新增的項目）
+POLLINATIONS_API_KEY=xxx node generate-pollinations.mjs --skip-existing
 ```
 
 跑完後 `apps/web/public/art/` 底下會多出對應的 webp 檔，直接 commit/push 回來，

--- a/azure-voyage/tools/artgen/generate-pollinations.mjs
+++ b/azure-voyage/tools/artgen/generate-pollinations.mjs
@@ -13,12 +13,14 @@
  *   POLLINATIONS_API_KEY=xxx node generate-pollinations.mjs
  *   POLLINATIONS_API_KEY=xxx node generate-pollinations.mjs --only=ship
  *   POLLINATIONS_API_KEY=xxx node generate-pollinations.mjs --id=sera
+ *   POLLINATIONS_API_KEY=xxx node generate-pollinations.mjs --skip-existing  # 只補缺的檔案
  *
  * 產出直接寫進 ../../apps/web/public/art/<category>/<id>.webp（相對這支腳本的
  * 位置算），跑完把整個 apps/web/public/art/ 目錄的變更 commit/push 回來，
  * 或直接把資料夾傳回來給我整理入庫都可以。
  */
 
+import { existsSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -31,11 +33,17 @@ const API_BASE = "https://image.pollinations.ai/prompt";
 
 const args = process.argv.slice(2);
 const dryRun = args.includes("--dry-run");
+const skipExisting = args.includes("--skip-existing");
 const onlyCategory = args.find((a) => a.startsWith("--only="))?.slice("--only=".length);
 const onlyId = args.find((a) => a.startsWith("--id="))?.slice("--id=".length);
 
 function selectEntries() {
-  return MANIFEST.filter((e) => (!onlyCategory || e.category === onlyCategory) && (!onlyId || e.id === onlyId));
+  return MANIFEST.filter(
+    (e) =>
+      (!onlyCategory || e.category === onlyCategory) &&
+      (!onlyId || e.id === onlyId) &&
+      (!skipExisting || !existsSync(path.join(OUT_ROOT, e.category, `${e.id}.webp`))),
+  );
 }
 
 /**

--- a/azure-voyage/tools/artgen/generate.mjs
+++ b/azure-voyage/tools/artgen/generate.mjs
@@ -8,11 +8,13 @@
  *   GEMINI_API_KEY=xxx node generate.mjs              # 產生 manifest 全部項目
  *   GEMINI_API_KEY=xxx node generate.mjs --only=ship  # 只做某 category
  *   GEMINI_API_KEY=xxx node generate.mjs --id=sera    # 只做某一筆（id 精確比對）
+ *   GEMINI_API_KEY=xxx node generate.mjs --skip-existing  # 只補缺的檔案
  *   node generate.mjs --dry-run                       # 不呼叫 API，只列出將產生的項目
  *
  * ⚠️ 不要把 API key 寫進任何檔案——一律用環境變數，用完即丟。
  */
 
+import { existsSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -25,11 +27,17 @@ const API_BASE = "https://generativelanguage.googleapis.com/v1beta";
 
 const args = process.argv.slice(2);
 const dryRun = args.includes("--dry-run");
+const skipExisting = args.includes("--skip-existing");
 const onlyCategory = args.find((a) => a.startsWith("--only="))?.slice("--only=".length);
 const onlyId = args.find((a) => a.startsWith("--id="))?.slice("--id=".length);
 
 function selectEntries() {
-  return MANIFEST.filter((e) => (!onlyCategory || e.category === onlyCategory) && (!onlyId || e.id === onlyId));
+  return MANIFEST.filter(
+    (e) =>
+      (!onlyCategory || e.category === onlyCategory) &&
+      (!onlyId || e.id === onlyId) &&
+      (!skipExisting || !existsSync(path.join(OUT_ROOT, e.category, `${e.id}.webp`))),
+  );
 }
 
 async function listModels(apiKey) {

--- a/azure-voyage/tools/artgen/manifest.mjs
+++ b/azure-voyage/tools/artgen/manifest.mjs
@@ -11,43 +11,62 @@ export const STYLE_PREFIX =
 export const NEGATIVE_PROMPT =
   "modern objects, photograph, real person, text, watermark, frame, border, low quality";
 
-// ── A. 港口場景（7 海域代表圖，size=2；size 1/3 港口沿用同張，缺檔則走 M13 剪影 fallback）──
-const PORT_SCENES = [
+// ── A. 港口場景（M18：7 海域 × 實際存在的規模，取代 M16 只做 size=2 代表圖的做法）──
+// 規模詞：size1=小漁村、size2=中型商港（M16 既有）、size3=首府大港；
+// coral_arc／dusk_expanse 在 ports.ts 裡沒有 size3 港口，故不產生對應圖。
+const SIZE_WORDS = {
+  1: "a small fishing village harbor, a handful of modest wooden docks, a few humble sailing boats",
+  2: "a mid-sized harbor town, sailing ships at anchor, stone piers",
+  3: "a grand capital harbor city, bustling waterfront crowded with tall ships, guild banners, grand stone architecture",
+};
+
+const PORT_SCENE_REGIONS = [
   {
     regionId: "north_reach",
+    sizes: [1, 2, 3],
     words: "snow-dusted timber roofs, cold windswept fjord harbor, grey stone piers, pine-covered hills",
   },
   {
     regionId: "amber_gulf",
+    sizes: [1, 2, 3],
     words: "golden sandstone buildings, calm turquoise gulf waters, olive groves on the hillside",
   },
   {
     regionId: "ironcliff",
+    sizes: [1, 2, 3],
     words: "dark iron-hued cliffs, rugged coastline, weathered granite piers, forge smoke over rooftops",
   },
   {
     regionId: "silkwind",
+    sizes: [1, 2, 3],
     words: "terraced silk-trade town, colorful silk banners, narrow strait with lantern-lit junks",
   },
   {
     regionId: "meridian",
+    sizes: [1, 2, 3],
     words: "bustling equatorial crossroads harbor, spice warehouses, distant storm clouds on the horizon",
   },
   {
     regionId: "coral_arc",
+    sizes: [1, 2],
     words: "coral reef lagoon, white sand beaches, turquoise shallows, thatched-roof stilt houses",
   },
   {
     regionId: "dusk_expanse",
+    sizes: [1, 2],
     words: "twilight sky with deep crimson clouds, remote windswept outpost, black volcanic rock shoreline",
   },
-].map(({ regionId, words }) => ({
-  category: "port-scene",
-  id: `${regionId}-s2`,
-  width: 1600,
-  height: 900,
-  prompt: `${STYLE_PREFIX}, wide establishing shot of a mid-sized harbor town, sailing ships at anchor, stone piers, ${words}`,
-}));
+];
+
+const PORT_SCENES = PORT_SCENE_REGIONS.flatMap(({ regionId, sizes, words }) =>
+  sizes.map((size) => ({
+    category: "port-scene",
+    id: `${regionId}-s${size}`,
+    width: 1600,
+    height: 900,
+    prompt: `${STYLE_PREFIX}, wide establishing shot of ${SIZE_WORDS[size]}, ${words}`,
+  })),
+);
 
 // ── B. 航海士立繪（12 名，特徵詞取自 officersPool.ts 的技能／數值傾向）──
 const OFFICER_PORTRAITS = [


### PR DESCRIPTION
## Summary
- `tools/artgen/manifest.mjs` 的港口場景從「7 海域各一張 size=2 代表圖」擴充成「7 海域 × 實際存在的規模」，共 19 筆（新增 12 筆），manifest 現有 64 筆
- `PortBanner` 元件本來就是用 `port.size` 組資產 id，不需要改動；補圖後 40 個港口會各自對應正確規模的場景圖，不再共用同一張代表圖
- 規模詞：size1=小漁村、size2=中型商港（沿用既有）、size3=首府大港
- 兩支生圖腳本（`generate.mjs` / `generate-pollinations.mjs`）都加上 `--skip-existing`，manifest 擴充後只想補新增項目時不用重打已完成的圖

本 PR 只含 manifest 與腳本變更，尚未實際生圖（等使用者用 Pollinations key 在本機執行 `--skip-existing` 後另外送出）。

## Test plan
- [x] `node --check` 三個修改過的檔案語法檢查通過
- [x] `node generate.mjs --dry-run` 確認 manifest 展開到 64 筆，新增 12 筆港口場景正確
- [x] `node generate-pollinations.mjs --dry-run --skip-existing --only=port-scene` 確認正確篩選出僅有的 12 筆新增項目

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013kDwmPmYtbENLcfMzDdnNF)_