### PR TITLE
M24：貿易路線規劃（跨港獲利建議）

### DIFF
--- a/azure-voyage/apps/api/src/modules/market/market.controller.ts
+++ b/azure-voyage/apps/api/src/modules/market/market.controller.ts
@@ -24,6 +24,15 @@ export class MarketController {
     return this.marketService.getPortDetail(user.userId, worldId, portId);
   }
 
+  @Get("trade-routes")
+  getTradeRoutes(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param("worldId") worldId: string,
+    @Param("portId") portId: string,
+  ) {
+    return this.marketService.getTradeRouteSuggestions(user.userId, worldId, portId);
+  }
+
   @Post("trade")
   trade(
     @CurrentUser() user: AuthenticatedUser,

--- a/azure-voyage/apps/api/src/modules/market/market.service.spec.ts
+++ b/azure-voyage/apps/api/src/modules/market/market.service.spec.ts
@@ -255,3 +255,57 @@ describe("MarketService.trade", () => {
     expect(state.marketStock.price).toBe(expectedPrice);
   });
 });
+
+describe("MarketService.getTradeRouteSuggestions", () => {
+  const ORIGIN_PORT_ID = "port.amber_gulf.aurelia";
+  const TARGET_PORT_ID = "port.amber_gulf.mirenport";
+
+  function makeTradeRoutePrisma() {
+    const world = { id: "w1", userId: "u1", status: "ACTIVE" };
+    const guild = { id: "g1", worldId: "w1", kind: "PLAYER" };
+    const portStates = [
+      {
+        portId: ORIGIN_PORT_ID,
+        market: [{ commodityId: "com.wine", price: 10, stock: 100, baseStock: 100 }],
+        influences: [] as { guildId: string; share: number }[],
+      },
+      {
+        portId: TARGET_PORT_ID,
+        market: [{ commodityId: "com.wine", price: 30, stock: 100, baseStock: 100 }],
+        influences: [] as { guildId: string; share: number }[],
+      },
+    ];
+
+    const prisma = {
+      gameWorld: { findUnique: jest.fn(async () => world) },
+      guild: { findFirstOrThrow: jest.fn(async () => guild) },
+      portState: { findMany: jest.fn(async () => portStates) },
+    } as unknown as PrismaService;
+
+    return { prisma };
+  }
+
+  it("suggests buying at the origin and selling at a port with a higher price", async () => {
+    const { prisma } = makeTradeRoutePrisma();
+    const service = new MarketService(prisma);
+
+    const suggestions = await service.getTradeRouteSuggestions("u1", "w1", ORIGIN_PORT_ID);
+
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0]).toMatchObject({
+      commodityId: "com.wine",
+      buyPortId: ORIGIN_PORT_ID,
+      sellPortId: TARGET_PORT_ID,
+    });
+    expect(suggestions[0].profitPerUnit).toBeGreaterThan(0);
+  });
+
+  it("rejects an unknown origin port", async () => {
+    const { prisma } = makeTradeRoutePrisma();
+    const service = new MarketService(prisma);
+
+    await expect(
+      service.getTradeRouteSuggestions("u1", "w1", "port.nowhere.fake"),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+});

--- a/azure-voyage/apps/api/src/modules/market/market.service.ts
+++ b/azure-voyage/apps/api/src/modules/market/market.service.ts
@@ -1,19 +1,24 @@
 import { Injectable } from "@nestjs/common";
 import {
   BALANCE,
+  bestTradeRoutesFrom,
   commodityById,
   computeMarketPrice,
   effectiveBuyPrice,
   effectiveSellPrice,
   goodwillFromTrade,
+  portById,
   portByIdOrFallback,
+  PORT_IDS,
   purserTradeBonus,
   shipClassById,
   type OfficerStats,
   type PortDetail,
+  type PortMarketSnapshot,
   type TradeFill,
   type TradeInput,
   type TradeResult,
+  type TradeRouteSuggestion,
 } from "@azure-voyage/shared";
 import { GameError } from "../../common/errors/game-error";
 import { awardExpToFleetOfficers } from "../officer/officer-growth.util";
@@ -66,6 +71,49 @@ export class MarketService {
       })),
       playerShare,
     };
+  }
+
+  /**
+   * 貿易路線建議（docs/01 §4.2、M24）：以 portId 為起點，比較全部港口目前的
+   * 有效買/賣價，算出「在起點買、去哪賣」的獲利建議，按「單位獲利/距離」排序。
+   * 只讀當下市場快照，不含 PURSER 職位加成（那是實際下單時才套用的折扣，
+   * 這裡單純是市場情報，維持跟 getPortDetail 一致的簡化）。
+   */
+  async getTradeRouteSuggestions(
+    userId: string,
+    worldId: string,
+    portId: string,
+    limit = 10,
+  ): Promise<TradeRouteSuggestion[]> {
+    const world = await this.prisma.gameWorld.findUnique({ where: { id: worldId } });
+    if (!world || world.userId !== userId) throw new GameError("NOT_FOUND");
+
+    const playerGuild = await this.prisma.guild.findFirstOrThrow({ where: { worldId, kind: "PLAYER" } });
+    // 只取現行 15 港（排除 M21 刪除後留下的孤兒 PortState，見 docs/13 §2）
+    const portStates = await this.prisma.portState.findMany({
+      where: { worldId, portId: { in: [...PORT_IDS] } },
+      include: { market: true, influences: true },
+    });
+
+    const snapshots: PortMarketSnapshot[] = portStates.map((ps) => {
+      const port = portById(ps.portId);
+      const share = Number(ps.influences.find((i) => i.guildId === playerGuild.id)?.share ?? 0);
+      return {
+        portId: ps.portId,
+        portName: port.name,
+        coord: port.coord,
+        listings: ps.market.map((m) => ({
+          commodityId: m.commodityId,
+          buyPrice: effectiveBuyPrice(m.price, share),
+          sellPrice: effectiveSellPrice(m.price, share),
+        })),
+      };
+    });
+
+    const origin = snapshots.find((s) => s.portId === portId);
+    if (!origin) throw new GameError("NOT_FOUND");
+
+    return bestTradeRoutesFrom(origin, snapshots, limit);
   }
 
   /**

--- a/azure-voyage/apps/web/src/app/play/[worldId]/page.tsx
+++ b/azure-voyage/apps/web/src/app/play/[worldId]/page.tsx
@@ -38,6 +38,7 @@ import { createGameSocket } from "@/lib/socket";
 import { SeaMap } from "@/game/SeaMap";
 import { FleetOverviewPanel } from "@/game/FleetOverviewPanel";
 import { TradePanel } from "@/game/TradePanel";
+import { TradeRoutePanel } from "@/game/TradeRoutePanel";
 import { TavernShipyardPanel } from "@/game/TavernShipyardPanel";
 import { BattleScene } from "@/game/BattleScene";
 import { ExplorationPanel } from "@/game/ExplorationPanel";
@@ -766,6 +767,16 @@ export default function PlayPage() {
                 onTraded={() => {
                   api.getWorld(worldId).then(setSnapshot).catch(() => undefined);
                 }}
+              />
+            </section>
+          )}
+
+          {activity === "DOCKED" && currentPort && (
+            <section className="panel">
+              <TradeRoutePanel
+                worldId={worldId}
+                portId={currentPort.portId}
+                onSetRoute={(targetPortId) => handleMapTarget({ targetPortId })}
               />
             </section>
           )}

--- a/azure-voyage/apps/web/src/game/TradeRoutePanel.tsx
+++ b/azure-voyage/apps/web/src/game/TradeRoutePanel.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { commodityById, type TradeRouteSuggestion } from "@azure-voyage/shared";
+import { api, ApiError } from "@/lib/api";
+
+interface Props {
+  worldId: string;
+  portId: string;
+  onSetRoute: (targetPortId: string) => void | Promise<void>;
+}
+
+/** 貿易路線建議（docs/01 §4.2；M24）：目前港口買、去哪賣最划算，按獲利/距離排序。 */
+export function TradeRoutePanel({ worldId, portId, onSetRoute }: Props) {
+  const [suggestions, setSuggestions] = useState<TradeRouteSuggestion[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    setSuggestions(null);
+    api
+      .getTradeRoutes(worldId, portId)
+      .then(setSuggestions)
+      .catch((err) => setError(err instanceof ApiError ? err.message : "載入貿易路線建議失敗"));
+  }, [worldId, portId]);
+
+  async function goTo(targetPortId: string) {
+    setBusy(true);
+    setError(null);
+    try {
+      await onSetRoute(targetPortId);
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : "設定航線失敗");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <h3 className="text-lg font-semibold text-foam">貿易路線建議</h3>
+      {error && <p className="text-sm text-red-400">{error}</p>}
+      {!suggestions && !error && <p className="text-sm text-slate-400">計算中…</p>}
+      {suggestions && suggestions.length === 0 && (
+        <p className="text-sm text-slate-400">目前沒有明顯有利可圖的路線。</p>
+      )}
+      {suggestions && suggestions.length > 0 && (
+        <ul className="space-y-2">
+          {suggestions.map((s, i) => (
+            <li
+              key={`${s.commodityId}-${s.sellPortId}-${i}`}
+              className="flex items-center justify-between rounded-md border border-foam/20 p-2 text-sm"
+            >
+              <span>
+                {commodityById(s.commodityId).name}：本港買 {s.buyPrice}，運至{" "}
+                <span className="text-foam">{s.sellPortName}</span> 賣 {s.sellPrice}
+                （單位獲利 <span className="text-gold">+{s.profitPerUnit}</span>・距離 {s.distance} 格）
+              </span>
+              <button className="btn-ghost" disabled={busy} onClick={() => goTo(s.sellPortId)}>
+                前往
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/azure-voyage/apps/web/src/lib/api.ts
+++ b/azure-voyage/apps/web/src/lib/api.ts
@@ -21,6 +21,7 @@ import {
   type RouteView,
   type TradeInput,
   type TradeResult,
+  type TradeRouteSuggestion,
   type WorldSnapshot,
   type WorldSummary,
 } from "@azure-voyage/shared";
@@ -124,6 +125,8 @@ export const api = {
     }),
   getPort: (worldId: string, portId: string) =>
     request<PortDetail>(`/worlds/${worldId}/ports/${portId}`),
+  getTradeRoutes: (worldId: string, portId: string) =>
+    request<TradeRouteSuggestion[]>(`/worlds/${worldId}/ports/${portId}/trade-routes`),
   trade: (worldId: string, portId: string, input: TradeInput) =>
     request<TradeResult>(`/worlds/${worldId}/ports/${portId}/trade`, {
       method: "POST",

--- a/azure-voyage/docs/16-trade-route-planning.md
+++ b/azure-voyage/docs/16-trade-route-planning.md
@@ -1,0 +1,40 @@
+# 16 — 貿易路線規劃（M24）
+
+> 回應玩家願望清單第二項的後半段：「貿易路線規劃」（前半段航海士養成見 docs/15）。
+
+## 1. 設計
+
+貿易路線規劃是「市場情報」工具，不是新的遊戲機制——玩家原本就能自己記錄哪個港
+賣什麼、去哪賣比較貴，這裡只是把這件事自動化：以目前所在港口為起點，算出「在這
+裡買、去哪個港賣」的獲利建議清單。
+
+沿用 docs/01 §1「全港名稱/座標可見」的既有 fog-of-war 設計（地圖本身從 M1 就全
+部可見，只有「是否到訪過」有差別）——這裡採一致的簡化：貿易路線建議直接讀取
+全部港口目前的市場快照，不要求玩家實際到訪過對方港口。這是一個「大帳房的貿易
+情報」而非需要親自跑一趟才能知道的秘密。
+
+## 2. 實作
+
+- `packages/shared/src/rules/tradeRoutes.ts`：純函式 `bestTradeRoutesFrom(origin, candidates, limit)`。
+  輸入「起點＋候選港」的市場快照（已算好各港的有效買/賣價），對每個起點有賣的
+  商品，找候選港裡賣價更高的，算出 `profitPerUnit`（單位獲利）與 `distance`
+  （hex 距離，沿用 `offsetDistance`），依 `score = profitPerUnit / max(1, distance)`
+  排序——距離會拉低分數，避免推薦「獲利看似很高但要跑半張地圖」的路線。
+- `MarketService.getTradeRouteSuggestions(userId, worldId, portId)`：抓全世界的
+  `PortState`（排除 M21 刪除後留下的孤兒港口，見 docs/13 §2），用玩家在各港的
+  影響力份額算出每港的有效買/賣價，組成快照丟給 `bestTradeRoutesFrom`。跟
+  `getPortDetail` 一樣不套用 PURSER 職位加成（那是實際下單時的折扣，這裡單純是
+  市場情報，維持簡化與行為一致）。
+- 新 API：`GET /worlds/:worldId/ports/:portId/trade-routes`。
+- 前端 `TradeRoutePanel`：停靠中顯示於港內面板，列出建議（商品／本港買價／目的
+  港賣價／單位獲利／距離），並附「前往」按鈕——直接重用既有的
+  `handleMapTarget({ targetPortId })`（跟點擊海圖港口設航線走同一條路徑），一鍵
+  把建議轉成實際航線，而不只是純資訊展示。
+
+## 3. 測試
+
+- `packages/shared`：`tradeRoutes.test.ts`（4 案例：正常建議、排除無利可圖/不重疊
+  商品、依「獲利/距離」而非純獲利排序、`limit` 生效）。
+- `apps/api`：`market.service.spec.ts` 新增 `MarketService.getTradeRouteSuggestions`
+  describe block（正常建議、未知起點港回 NOT_FOUND）。
+- `apps/web`：`next build` 通過型別檢查與靜態頁面產生。

--- a/azure-voyage/packages/shared/src/index.ts
+++ b/azure-voyage/packages/shared/src/index.ts
@@ -28,6 +28,7 @@ export * from "./rules/dominance";
 export * from "./rules/worldgen";
 export * from "./rules/aiFallback";
 export * from "./rules/officerGrowth";
+export * from "./rules/tradeRoutes";
 
 // schemas & errors
 export * from "./errors";

--- a/azure-voyage/packages/shared/src/rules/tradeRoutes.test.ts
+++ b/azure-voyage/packages/shared/src/rules/tradeRoutes.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { bestTradeRoutesFrom, type PortMarketSnapshot } from "./tradeRoutes";
+
+function port(portId: string, portName: string, coord: { col: number; row: number }, listings: { commodityId: string; buyPrice: number; sellPrice: number }[]): PortMarketSnapshot {
+  return { portId, portName, coord, listings };
+}
+
+describe("bestTradeRoutesFrom", () => {
+  it("suggests a profitable route when a commodity sells higher elsewhere", () => {
+    const origin = port("p.a", "A港", { col: 0, row: 0 }, [{ commodityId: "com.wine", buyPrice: 10, sellPrice: 9 }]);
+    const target = port("p.b", "B港", { col: 4, row: 0 }, [{ commodityId: "com.wine", buyPrice: 20, sellPrice: 25 }]);
+
+    const result = bestTradeRoutesFrom(origin, [origin, target]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      commodityId: "com.wine",
+      buyPortId: "p.a",
+      sellPortId: "p.b",
+      sellPortName: "B港",
+      profitPerUnit: 15, // 25 - 10
+    });
+    expect(result[0].distance).toBeGreaterThan(0);
+  });
+
+  it("excludes the origin port itself and non-profitable/unmatched commodities", () => {
+    const origin = port("p.a", "A港", { col: 0, row: 0 }, [
+      { commodityId: "com.wine", buyPrice: 10, sellPrice: 9 },
+      { commodityId: "com.iron_ore", buyPrice: 5, sellPrice: 4 },
+    ]);
+    const sameGoodCheaperElsewhere = port("p.b", "B港", { col: 1, row: 0 }, [
+      { commodityId: "com.wine", buyPrice: 8, sellPrice: 7 }, // 賣價比買價低，無利可圖
+    ]);
+    const noOverlap = port("p.c", "C港", { col: 2, row: 0 }, [
+      { commodityId: "com.silk", buyPrice: 30, sellPrice: 40 }, // 起點根本沒賣這個商品
+    ]);
+
+    const result = bestTradeRoutesFrom(origin, [origin, sameGoodCheaperElsewhere, noOverlap]);
+    expect(result).toHaveLength(0);
+  });
+
+  it("sorts by profit-per-distance score, not raw profit alone", () => {
+    const origin = port("p.a", "A港", { col: 0, row: 0 }, [{ commodityId: "com.wine", buyPrice: 10, sellPrice: 10 }]);
+    const near = port("p.near", "近港", { col: 1, row: 0 }, [{ commodityId: "com.wine", buyPrice: 0, sellPrice: 20 }]);
+    const far = port("p.far", "遠港", { col: 50, row: 0 }, [{ commodityId: "com.wine", buyPrice: 0, sellPrice: 25 }]);
+
+    const result = bestTradeRoutesFrom(origin, [origin, near, far]);
+    expect(result[0].sellPortId).toBe("p.near"); // 獲利略低但距離近很多，分數應該較高
+  });
+
+  it("respects the limit parameter", () => {
+    const origin = port("p.a", "A港", { col: 0, row: 0 }, [{ commodityId: "com.wine", buyPrice: 1, sellPrice: 1 }]);
+    const targets = Array.from({ length: 20 }, (_, i) =>
+      port(`p.${i}`, `港${i}`, { col: i + 1, row: 0 }, [{ commodityId: "com.wine", buyPrice: 0, sellPrice: 10 + i }]),
+    );
+
+    const result = bestTradeRoutesFrom(origin, [origin, ...targets], 5);
+    expect(result).toHaveLength(5);
+  });
+});

--- a/azure-voyage/packages/shared/src/rules/tradeRoutes.ts
+++ b/azure-voyage/packages/shared/src/rules/tradeRoutes.ts
@@ -1,0 +1,61 @@
+/**
+ * 貿易路線建議（docs/01 §4.2、M24）。純函式：輸入「起點港＋候選港」的市場快照
+ * （已算好各港的有效買/賣價），算出「在起點買、去哪個港賣」的獲利建議，
+ * 按「單位獲利 / 航行距離」排序——距離用 hex 格數，越近的高獲利路線分數越高。
+ */
+import { offsetDistance, type OffsetCoord } from "./hex";
+
+export interface PortMarketSnapshot {
+  portId: string;
+  portName: string;
+  coord: OffsetCoord;
+  /** 該港各商品的目前有效買/賣價（已套用影響力折扣） */
+  listings: { commodityId: string; buyPrice: number; sellPrice: number }[];
+}
+
+export interface TradeRouteSuggestion {
+  commodityId: string;
+  buyPortId: string;
+  buyPrice: number;
+  sellPortId: string;
+  sellPortName: string;
+  sellPrice: number;
+  profitPerUnit: number;
+  distance: number;
+  /** 排序依據：單位獲利 / max(1, 距離)，距離越近、獲利越高分數越高 */
+  score: number;
+}
+
+export function bestTradeRoutesFrom(
+  origin: PortMarketSnapshot,
+  candidates: readonly PortMarketSnapshot[],
+  limit = 10,
+): TradeRouteSuggestion[] {
+  const suggestions: TradeRouteSuggestion[] = [];
+
+  for (const listing of origin.listings) {
+    for (const target of candidates) {
+      if (target.portId === origin.portId) continue;
+      const targetListing = target.listings.find((l) => l.commodityId === listing.commodityId);
+      if (!targetListing) continue;
+
+      const profitPerUnit = targetListing.sellPrice - listing.buyPrice;
+      if (profitPerUnit <= 0) continue;
+
+      const distance = offsetDistance(origin.coord, target.coord);
+      suggestions.push({
+        commodityId: listing.commodityId,
+        buyPortId: origin.portId,
+        buyPrice: listing.buyPrice,
+        sellPortId: target.portId,
+        sellPortName: target.portName,
+        sellPrice: targetListing.sellPrice,
+        profitPerUnit,
+        distance,
+        score: profitPerUnit / Math.max(1, distance),
+      });
+    }
+  }
+
+  return suggestions.sort((a, b) => b.score - a.score).slice(0, limit);
+}


### PR DESCRIPTION
## 摘要

回應玩家願望清單第二項的後半段「貿易路線規劃」（前半段航海士養成見 M23/docs/15）。

- 新增 `packages/shared/src/rules/tradeRoutes.ts` 純函式 `bestTradeRoutesFrom`：以目前所在港口為起點，比較全部港口的有效買/賣價，算出「在這裡買、去哪賣」的獲利建議，依「單位獲利 / hex 距離」排序，避免推薦看似獲利高但要跑半張地圖的路線。
- `MarketService.getTradeRouteSuggestions`：抓全世界的 `PortState`（排除 M21 刪除後留下的孤兒港口），用玩家在各港的影響力份額算出每港有效買/賣價。
- 新 API：`GET /worlds/:worldId/ports/:portId/trade-routes`。
- 前端新增 `TradeRoutePanel`，停靠中顯示於港內面板，附「前往」按鈕直接設定航線（重用既有的 `handleMapTarget`，跟點擊海圖港口走同一條路徑）。

延續 docs/01 §1「全港名稱/座標可見」的既有 fog-of-war 設計，貿易路線建議直接讀取全部港口的市場快照，不要求玩家實際到訪過對方港口（維持跟 `getPortDetail` 一致的行為）。

詳見 docs/16。

## Test plan

- [x] `pnpm --filter @azure-voyage/shared exec vitest run` — 150 tests pass（新增 `tradeRoutes.test.ts` 4 案例）
- [x] `apps/api`：`npx jest` — 141 tests pass（`market.service.spec.ts` 新增 `getTradeRouteSuggestions` 案例）
- [x] `pnpm --filter @azure-voyage/api exec tsc --noEmit` — 無型別錯誤
- [x] `pnpm --filter @azure-voyage/web build`（`next build`，含型別檢查）— 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013kDwmPmYtbENLcfMzDdnNF

---
_Generated by [Claude Code](https://claude.ai/code/session_013kDwmPmYtbENLcfMzDdnNF)_