### PR TITLE
修復：海戰後艦隊卡住無法動彈

### DIFF
--- a/azure-voyage/apps/api/prisma/migrations/20260713094836_battle_fleet_id/migration.sql
+++ b/azure-voyage/apps/api/prisma/migrations/20260713094836_battle_fleet_id/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Battle" ADD COLUMN     "fleetId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "Battle_worldId_fleetId_status_idx" ON "Battle"("worldId", "fleetId", "status");

--- a/azure-voyage/apps/api/prisma/schema.prisma
+++ b/azure-voyage/apps/api/prisma/schema.prisma
@@ -270,6 +270,9 @@ model Battle {
   id          String       @id @default(cuid())
   worldId     String
   world       GameWorld    @relation(fields: [worldId], references: [id], onDelete: Cascade)
+  // 玩家艦隊 id（bug 修復：讓「重新連線時我的艦隊是否還在一場進行中的海戰裡」可查，
+  // 不必再拿艦隊船隻 id 去逐一比對 state.units；舊資料/系統戰鬥可能沒有，留 nullable）。
+  fleetId     String?
   status      BattleStatus @default(ONGOING)
   seed        Int
   round       Int          @default(1)
@@ -278,6 +281,7 @@ model Battle {
   actionLog   Json         @default("[]")
 
   @@index([worldId, status])
+  @@index([worldId, fleetId, status])
 }
 
 // ─────────────────────── 發現物 ───────────────────────

--- a/azure-voyage/apps/api/src/modules/battle/encounter.service.spec.ts
+++ b/azure-voyage/apps/api/src/modules/battle/encounter.service.spec.ts
@@ -61,11 +61,13 @@ describe("EncounterService.rollEncounters", () => {
       if (battles.length > 0) {
         found = true;
         expect(fleetUpdates).toContainEqual({ activity: "IN_BATTLE" });
-        const battleData = battles[0] as { state: { units: { side: string }[] } };
+        const battleData = battles[0] as { fleetId: string; state: { units: { side: string }[] } };
         const playerUnits = battleData.state.units.filter((u) => u.side === "PLAYER");
         const enemyUnits = battleData.state.units.filter((u) => u.side === "ENEMY");
         expect(playerUnits).toHaveLength(1);
         expect(enemyUnits.length).toBeGreaterThanOrEqual(1);
+        // bug 修復：battle 要記下 fleetId，重新連線時才查得到「我的艦隊在哪場海戰裡」
+        expect(battleData.fleetId).toBe("f1");
       }
     }
     expect(found).toBe(true);

--- a/azure-voyage/apps/api/src/modules/battle/encounter.service.ts
+++ b/azure-voyage/apps/api/src/modules/battle/encounter.service.ts
@@ -98,6 +98,7 @@ export class EncounterService {
       const battle = await this.prisma.battle.create({
         data: {
           worldId,
+          fleetId: fleet.id,
           seed: battleSeed,
           startedTick: tick,
           state: auto.state as unknown as Prisma.InputJsonValue,

--- a/azure-voyage/apps/api/src/modules/world/world.service.spec.ts
+++ b/azure-voyage/apps/api/src/modules/world/world.service.spec.ts
@@ -127,7 +127,11 @@ describe("WorldService", () => {
 // M21 縮編後既有存檔可能還有艦隊/待業航海士停在已刪除的港口 id（如 port.amber_gulf.vireno）；
 // getSnapshot() 讀取時要自我修復成最近的存續港口，而不是讓 portById() 崩潰。
 describe("WorldService#getSnapshot self-heal for removed port ids", () => {
-  function makeSnapshotPrismaMock(fleet: FleetRow, tavernOfficers: OfficerRow[]) {
+  function makeSnapshotPrismaMock(
+    fleet: FleetRow,
+    tavernOfficers: OfficerRow[],
+    battles: { id: string; fleetId: string }[] = [],
+  ) {
     const fleets = [fleet];
     const officers = [...tavernOfficers];
     const prisma = {
@@ -159,6 +163,7 @@ describe("WorldService#getSnapshot self-heal for removed port ids", () => {
       },
       portInfluence: { findMany: jest.fn(async () => []) },
       discoveryRecord: { count: jest.fn(async () => 0) },
+      battle: { findMany: jest.fn(async () => battles) },
       $transaction: jest.fn(async (arg: unknown) => {
         if (typeof arg === "function") return arg(prisma);
         return Promise.all(arg as Promise<unknown>[]);
@@ -249,5 +254,51 @@ describe("WorldService#getSnapshot self-heal for removed port ids", () => {
 
     expect(snapshot.fleets[0].dockedPortId).toBe("port.amber_gulf.aurelia");
     expect(prisma.fleet.update).not.toHaveBeenCalled();
+  });
+
+  // bug 修復：重新連線時要能知道艦隊卡在哪一場進行中的海戰裡，前端才能接回戰鬥畫面
+  // 而不是永遠卡在 IN_BATTLE 卻看不到任何戰鬥介面。
+  it("surfaces activeBattleId when the fleet is in an ongoing battle", async () => {
+    const fleet: FleetRow = {
+      id: "f1",
+      worldId: "w1",
+      guildId: "g-player",
+      name: "第一艦隊",
+      activity: "IN_BATTLE",
+      posQ: 0,
+      posR: 0,
+      dockedPortId: null,
+      food: 10,
+      water: 10,
+      morale: 100,
+    };
+    const { prisma } = makeSnapshotPrismaMock(fleet, [], [{ id: "battle1", fleetId: "f1" }]);
+    const service = new WorldService(prisma);
+
+    const snapshot = await service.getSnapshot("u1", "w1");
+
+    expect(snapshot.fleets[0].activeBattleId).toBe("battle1");
+  });
+
+  it("leaves activeBattleId null when there is no ongoing battle for the fleet", async () => {
+    const fleet: FleetRow = {
+      id: "f1",
+      worldId: "w1",
+      guildId: "g-player",
+      name: "第一艦隊",
+      activity: "DOCKED",
+      posQ: 0,
+      posR: 0,
+      dockedPortId: "port.amber_gulf.aurelia",
+      food: 10,
+      water: 10,
+      morale: 100,
+    };
+    const { prisma } = makeSnapshotPrismaMock(fleet, []);
+    const service = new WorldService(prisma);
+
+    const snapshot = await service.getSnapshot("u1", "w1");
+
+    expect(snapshot.fleets[0].activeBattleId).toBeNull();
   });
 });

--- a/azure-voyage/apps/api/src/modules/world/world.service.ts
+++ b/azure-voyage/apps/api/src/modules/world/world.service.ts
@@ -278,6 +278,14 @@ export class WorldService {
       );
     }
 
+    // bug 修復：重新連線時要能知道「我的艦隊是否還在一場進行中的海戰裡」，否則前端
+    // 沒收到當初那次 SERVER_BATTLE_START 推播的話，會永遠卡在 IN_BATTLE 卻沒有戰鬥畫面。
+    const ongoingBattles = await this.prisma.battle.findMany({
+      where: { worldId, status: "ONGOING", fleetId: { in: fleets.map((f) => f.id) } },
+      select: { id: true, fleetId: true },
+    });
+    const activeBattleIdByFleetId = new Map(ongoingBattles.map((b) => [b.fleetId!, b.id]));
+
     const playerGuild = guilds.find((g) => g.kind === "PLAYER");
     if (!playerGuild) throw new GameError("INTERNAL", "world has no player guild");
 
@@ -309,6 +317,7 @@ export class WorldService {
         food: f.food,
         water: f.water,
         morale: f.morale,
+        activeBattleId: activeBattleIdByFleetId.get(f.id) ?? null,
         ships: f.ships.map((s) => ({
           id: s.id,
           shipClassId: s.shipClassId,

--- a/azure-voyage/apps/web/src/app/play/[worldId]/page.tsx
+++ b/azure-voyage/apps/web/src/app/play/[worldId]/page.tsx
@@ -279,6 +279,21 @@ export default function PlayPage() {
     };
   }, [worldId, router]);
 
+  // bug 修復：重新連線／重新整理時，若艦隊其實還卡在一場進行中的海戰裡
+  // （沒收到當初那次 SERVER_BATTLE_START 推播），主動把戰鬥畫面接回來，
+  // 而不是讓玩家看到正常海圖卻永遠無法動彈。
+  useEffect(() => {
+    const activeBattleId = snapshot?.fleets[0]?.activeBattleId;
+    if (!activeBattleId || battleId) return;
+    api
+      .getBattle(worldId, activeBattleId)
+      .then((battle) => {
+        setBattleId(battle.id);
+        setBattleState(battle.state);
+      })
+      .catch(() => undefined);
+  }, [snapshot, worldId, battleId]);
+
   const fleet = snapshot?.fleets[0];
   playerFleetIdRef.current = fleet?.id ?? playerFleetIdRef.current;
   const activity = fleetDelta?.activity ?? fleet?.activity;

--- a/azure-voyage/apps/web/src/lib/api.ts
+++ b/azure-voyage/apps/web/src/lib/api.ts
@@ -5,6 +5,7 @@ import {
   type ApiResponse,
   type AuthResult,
   type AuthTokens,
+  type BattleView,
   type CreateWorldInput,
   type DialogueRequest,
   type DialogueResponse,
@@ -107,6 +108,8 @@ export const api = {
     request<WorldSummary>("/worlds", { method: "POST", body: input }),
   getWorld: (id: string) => request<WorldSnapshot>(`/worlds/${id}`),
   abandonWorld: (id: string) => request<WorldSummary>(`/worlds/${id}`, { method: "DELETE" }),
+  getBattle: (worldId: string, battleId: string) =>
+    request<BattleView>(`/worlds/${worldId}/battles/${battleId}`),
   setRoute: (
     worldId: string,
     fleetId: string,

--- a/azure-voyage/docs/19-battle-resume-repair.md
+++ b/azure-voyage/docs/19-battle-resume-repair.md
@@ -1,0 +1,70 @@
+# 19 — 海戰卡住無法動彈的修復（production bug）
+
+> 對應真實回報：「遇到海賊之後，都會bug無法動彈」。玩家的艦隊其實正卡在一場
+> `ONGOING` 的海戰裡（`activity=IN_BATTLE`），但畫面顯示的是完全正常的海圖，
+> 沒有任何戰鬥 UI，也點不到任何能繼續遊戲的按鈕。
+
+## 0. 根本原因
+
+戰鬥畫面（`battleId` / `battleState`）在前端只有一個來源：即時 WS 事件
+`SERVER_BATTLE_START`。玩家一旦錯過那一次推播——重新整理分頁、斷線重連、切分頁
+背景太久、手機瀏覽器把分頁凍結——就再也沒有任何機制能把戰鬥畫面接回來。
+
+而 `VoyageService` 的 `NON_ROUTABLE_ACTIVITIES = new Set(["IN_BATTLE", "EXPLORING"])`
+在 `activity=IN_BATTLE` 時會擋掉所有設定航線／操舵的請求，於是玩家會卡在一個
+「看起來很正常但什麼都做不了」的海圖畫面，且沒有任何錯誤訊息或提示。
+
+深一層看，`Battle` model 原本也沒有 `fleetId` 欄位，就算想在重新連線時主動查
+「我的艦隊是不是還在一場進行中的海戰裡」也做不到。
+
+## 1. 修復設計
+
+**`apps/api/prisma/schema.prisma` / 新遷移 `20260713094836_battle_fleet_id`**：
+
+- `Battle` 新增 `fleetId String?`（nullable：舊資料或系統戰鬥可能沒有）與索引
+  `@@index([worldId, fleetId, status])`，讓「這個世界裡，這支艦隊，是否有一場
+  `ONGOING` 的戰鬥」變成一個可以直接查的問題。
+
+**`apps/api/src/modules/battle/encounter.service.ts`**：
+
+- 建立 `Battle` 時多帶入 `fleetId: fleet.id`。
+
+**`packages/shared/src/schemas/world.ts`**：
+
+- `FleetViewSchema` 新增 `activeBattleId: z.string().nullable()`。
+
+**`apps/api/src/modules/world/world.service.ts`（`getSnapshot()`）**：
+
+- 額外查一次「這個世界裡，屬於目前這些艦隊、狀態是 `ONGOING` 的 `Battle`」，
+  組成 `fleetId → battleId` 的 map，塞進每個 `FleetView.activeBattleId`。
+
+**前端（`apps/web/src/app/play/[worldId]/page.tsx` / `apps/web/src/lib/api.ts`）**：
+
+- 新增 `api.getBattle(worldId, battleId)`。
+- 新增一個 `useEffect`：每次收到快照，若 `snapshot.fleets[0].activeBattleId`
+  有值、而本地 `battleId` 還是空的，就主動打 `getBattle` 把戰鬥畫面接回來
+  （設定 `battleId` / `battleState`）。這樣不管玩家是重新整理、重新連線、還是
+  剛好在推播那一刻沒連上，只要艦隊實際上還在戰鬥中，畫面一定會顯示戰鬥 UI。
+
+## 2. 不動的部分
+
+- 戰鬥本身的回合制邏輯（`BattleService`）、`SERVER_BATTLE_START` 即時推播本身
+  都不變——這次修的是「錯過推播之後要怎麼補回來」，不是戰鬥系統本身。
+- `NON_ROUTABLE_ACTIVITIES` 擋航線設定的邏輯不變：戰鬥中本來就不該讓艦隊亂跑，
+  正確行為是把戰鬥畫面接回來、而不是放行航線指令。
+
+## 3. 測試
+
+- `apps/api/src/modules/world/world.service.spec.ts` 新增兩則：艦隊有進行中戰鬥
+  時 `activeBattleId` 正確帶出、沒有時維持 `null`。
+- `apps/api/src/modules/battle/encounter.service.spec.ts`：既有「觸發海戰」測試
+  補上 `battleData.fleetId` 斷言，確保新戰鬥一定會記下艦隊 id。
+- 真實環境端對端驗證（本機 Postgres + Redis + 真實 API/web server + Playwright）：
+  直接在 DB 插入一筆 `ONGOING` 且帶 `fleetId` 的 `Battle`、把艦隊 `activity` 設成
+  `IN_BATTLE`（模擬「從沒收到過那次即時推播」），重新整理分頁後畫面正確顯示
+  「海戰進行中」與完整戰鬥操作按鈕（移動／砲擊／接舷／搶修／逃跑），修復前
+  同樣的操作只會看到正常但無法動彈的海圖。
+
+既有的 API 全部測試（19 個 suite、146 個測試）、`@azure-voyage/shared` 全部測試
+（22 個檔案、157 個測試，含更新 `schemas.test.ts` 的快照 fixture 補上
+`activeBattleId: null`）、API/web `tsc --noEmit`、`next build` 全數維持綠燈。

--- a/azure-voyage/packages/shared/src/schemas/schemas.test.ts
+++ b/azure-voyage/packages/shared/src/schemas/schemas.test.ts
@@ -86,6 +86,7 @@ describe("world schemas", () => {
               exp: 0,
             },
           ],
+          activeBattleId: null,
         },
       ],
       knownPorts: [

--- a/azure-voyage/packages/shared/src/schemas/world.ts
+++ b/azure-voyage/packages/shared/src/schemas/world.ts
@@ -85,6 +85,8 @@ export const FleetViewSchema = z.object({
   morale: z.number().int(),
   ships: z.array(ShipViewSchema),
   officers: z.array(OfficerViewSchema),
+  /** activity 為 IN_BATTLE 時，這場進行中海戰的 id（bug 修復：讓重新連線的前端能接回戰鬥畫面） */
+  activeBattleId: z.string().nullable(),
 });
 export type FleetView = z.infer<typeof FleetViewSchema>;
 


### PR DESCRIPTION
## 摘要

- 修復 production bug：玩家回報「遇到海賊之後，都會bug無法動彈」。
- 根本原因：戰鬥畫面只靠一次性的 `SERVER_BATTLE_START` WS 推播觸發；只要玩家
  錯過那次推播（重新整理、斷線重連、分頁背景太久），艦隊 `activity=IN_BATTLE`
  卻永遠沒有戰鬥 UI 可以互動，也被 `NON_ROUTABLE_ACTIVITIES` 擋掉所有航行操作。
- 修法：`Battle` 新增 `fleetId`（新遷移 `20260713094836_battle_fleet_id`），
  `WorldSnapshot` 的 `FleetView` 新增 `activeBattleId`；前端收到快照時若偵測到
  艦隊其實在進行中的海戰但本地沒有 `battleId`，主動呼叫新增的
  `api.getBattle()` 把戰鬥畫面接回來。
- 詳見 `docs/19-battle-resume-repair.md`。

## 測試

- [x] `apps/api`：全部 19 個測試檔、146 個測試通過（含新增的 `activeBattleId`
      斷言與 `encounter.service.spec.ts` 的 `fleetId` 斷言）。
- [x] `@azure-voyage/shared`：全部 22 個測試檔、157 個測試通過（更新
      `schemas.test.ts` fixture 補上 `activeBattleId: null`）。
- [x] `apps/api` / `apps/web`：`tsc --noEmit` 皆通過。
- [x] `apps/web`：`next build` 通過。
- [x] 真實環境端對端驗證：本機 Postgres + Redis + 真實 API/web server +
      Playwright，直接在 DB 插入一筆 `ONGOING` 且帶 `fleetId` 的 `Battle`
      模擬「錯過即時推播」情境，重新整理分頁後畫面正確顯示完整戰鬥 UI
      （移動／砲擊／接舷／搶修／逃跑），修復前同樣操作只會看到卡住的正常海圖。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013kDwmPmYtbENLcfMzDdnNF

---
_Generated by [Claude Code](https://claude.ai/code/session_013kDwmPmYtbENLcfMzDdnNF)_