### PR TITLE
修復：戰敗後回饋不明確，誤以為艦隊被無故重置回起始城市

### DIFF
--- a/azure-voyage/apps/api/src/modules/battle/battle.service.spec.ts
+++ b/azure-voyage/apps/api/src/modules/battle/battle.service.spec.ts
@@ -1,6 +1,6 @@
-import { initBattleState, shipClassById, unitFromShip, type BattleState } from "@azure-voyage/shared";
+import { HOME_PORT_ID, initBattleState, shipClassById, unitFromShip, type BattleState } from "@azure-voyage/shared";
 import type { PrismaService } from "../../prisma/prisma.service";
-import { BattleService } from "./battle.service";
+import { BATTLE_END_EVENT, BattleService } from "./battle.service";
 
 const SEED = 12345;
 
@@ -17,6 +17,18 @@ function makeOneShotUnits() {
   const lugger = shipClassById("ship.lugger");
   const player = unitFromShip("s1", "PLAYER", "旗艦", lugger, { q: -2, r: 0 }, lugger.maxHull, 8);
   const enemy = unitFromShip("enemy-0", "ENEMY", "海賊船", lugger, { q: 2, r: 0 }, 1, 4);
+  return [player, enemy];
+}
+
+/**
+ * 玩家血量僅剩 1、敵方血量健康：玩家 REPAIR（不攻擊）後，敵方 AI 必定選擇 FIRE
+ * （血量健康不會觸發逃跑判定），FIRE 傷害保底至少 1 點，保證一擊擊沉玩家——
+ * 不必掃描 seed 就能穩定重現 PLAYER_LOSE，用來驗證戰敗贖金與拖回母港的結算。
+ */
+function makePlayerAboutToLoseUnits() {
+  const lugger = shipClassById("ship.lugger");
+  const player = unitFromShip("s1", "PLAYER", "旗艦", lugger, { q: -2, r: 0 }, 1, 8);
+  const enemy = unitFromShip("enemy-0", "ENEMY", "海賊船", lugger, { q: 2, r: 0 }, 50, 4);
   return [player, enemy];
 }
 
@@ -127,6 +139,32 @@ describe("BattleService.applyAction", () => {
     expect(Number(guild.gold)).toBeGreaterThan(1000);
     expect(fleet).toMatchObject({ activity: "SAILING" });
     expect(ships.find((s) => s.id === "s1")).toBeDefined(); // 玩家船隻保留
+  });
+
+  // bug 修復：戰敗被拖回母港＋扣贖金，前端要靠 ransom 顯示明確的過場畫面
+  it("charges ransom and drags the fleet home on PLAYER_LOSE", async () => {
+    const state = initBattleState(makePlayerAboutToLoseUnits());
+    const { prisma, guild, fleet } = makePrisma(state, { gold: 1000 });
+    const emit = jest.fn();
+    const service = new BattleService(prisma, { emit } as never);
+
+    // 玩家 MOVE（不回血、不攻擊敵方），讓敵方接著 FIRE 一擊擊沉血量僅剩 1 的玩家船
+    const result = await service.applyAction("u1", "w1", "b1", {
+      type: "MOVE",
+      unitId: "s1",
+      to: { q: -1, r: 0 },
+    });
+
+    expect(result.status).toBe("PLAYER_LOSE");
+    expect(Number(guild.gold)).toBeLessThan(1000);
+    expect(fleet).toMatchObject({ activity: "DOCKED", dockedPortId: HOME_PORT_ID });
+
+    const endCall = emit.mock.calls.find(([event]) => event === BATTLE_END_EVENT);
+    expect(endCall).toBeDefined();
+    const payload = endCall![1] as { payload: { status: string; ransom?: number } };
+    expect(payload.payload.status).toBe("PLAYER_LOSE");
+    expect(payload.payload.ransom).toBeGreaterThan(0);
+    expect(payload.payload.ransom).toBe(1000 - Number(guild.gold));
   });
 
   it("awards exp to the fleet's officers on PLAYER_WIN (M23)", async () => {

--- a/azure-voyage/apps/api/src/modules/battle/battle.service.ts
+++ b/azure-voyage/apps/api/src/modules/battle/battle.service.ts
@@ -94,8 +94,9 @@ export class BattleService {
         },
       });
 
+      let ransom: number | undefined;
       if (outcome) {
-        await this.resolveBattleEnd(tx, state, outcome);
+        ransom = await this.resolveBattleEnd(tx, state, outcome);
       }
 
       this.events.emit(BATTLE_UPDATE_EVENT, {
@@ -103,25 +104,28 @@ export class BattleService {
         payload: { battleId, state, log: log[log.length - 1] },
       });
       if (outcome) {
-        this.events.emit(BATTLE_END_EVENT, { worldId, payload: { battleId, status } });
+        this.events.emit(BATTLE_END_EVENT, { worldId, payload: { battleId, status, ransom } });
       }
 
       return { state, status };
     });
   }
 
-  /** 戰後結算：持久化船隻損傷/沉沒、戰利品或贖金，並讓艦隊恢復可航行狀態（docs/05 §5）。 */
+  /**
+   * 戰後結算：持久化船隻損傷/沉沒、戰利品或贖金，並讓艦隊恢復可航行狀態（docs/05 §5）。
+   * 回傳值僅 PLAYER_LOSE 有意義（扣了多少贖金），供上層推播給前端過場畫面顯示。
+   */
   private async resolveBattleEnd(
     tx: Prisma.TransactionClient,
     state: BattleState,
     outcome: "PLAYER_WIN" | "PLAYER_LOSE" | "FLED",
-  ): Promise<void> {
+  ): Promise<number | undefined> {
     const playerUnits = state.units.filter((u) => u.side === "PLAYER");
-    if (playerUnits.length === 0) return;
+    if (playerUnits.length === 0) return undefined;
 
     const ships = await tx.ship.findMany({ where: { id: { in: playerUnits.map((u) => u.id) } } });
     const fleetId = ships[0]?.fleetId;
-    if (!fleetId) return;
+    if (!fleetId) return undefined;
     const fleet = await tx.fleet.findUniqueOrThrow({ where: { id: fleetId } });
 
     const survivingCount = playerUnits.filter((u) => !u.destroyed).length;
@@ -148,8 +152,10 @@ export class BattleService {
       }
       await tx.fleet.update({ where: { id: fleetId }, data: { activity: "SAILING" } });
       await awardExpToFleetOfficers(tx, fleetId, BALANCE.OFFICER_EXP_PER_BATTLE_WIN);
+      return undefined;
     } else if (outcome === "FLED") {
       await tx.fleet.update({ where: { id: fleetId }, data: { activity: "SAILING" } });
+      return undefined;
     } else {
       const guild = await tx.guild.findUniqueOrThrow({ where: { id: fleet.guildId } });
       const ransom = Math.round(Number(guild.gold) * BALANCE.DEFEAT_RANSOM_RATIO);
@@ -168,6 +174,7 @@ export class BattleService {
           route: Prisma.DbNull,
         },
       });
+      return ransom;
     }
   }
 }

--- a/azure-voyage/apps/web/src/app/play/[worldId]/page.tsx
+++ b/azure-voyage/apps/web/src/app/play/[worldId]/page.tsx
@@ -10,6 +10,7 @@ import {
   ERROR_MESSAGES_ZH_TW,
   firstNavigableHeading,
   HEXMAP,
+  HOME_PORT_ID,
   openingNarrativeFor,
   portById,
   regionForCoord,
@@ -249,14 +250,20 @@ export default function PlayPage() {
       setBattleLog((prev) => [...prev, payload.log]);
     });
     socket.on(WS_EVENTS.BATTLE_END, (payload: ServerBattleEndPayload) => {
-      setNotice(
-        payload.status === "PLAYER_WIN"
-          ? "戰鬥勝利！"
-          : payload.status === "FLED"
-            ? "成功脫離戰場。"
-            : "艦隊戰敗，被拖回母港療傷……",
-      );
-      setNoticeKind(null);
+      if (payload.status === "PLAYER_LOSE") {
+        // bug 修復：戰敗被拖回母港是刻意設計的懲罰，但過去只用一閃即逝的
+        // notice 顯示，很容易被忽略／切分頁錯過，玩家常常搞不清楚為什麼
+        // 「無緣無故」回到起始城市。改用跟入港一樣明確、不可略過的過場畫面。
+        setCutscene({
+          kind: "defeat",
+          portId: HOME_PORT_ID,
+          day: tickRef.current,
+          ransom: payload.ransom,
+        });
+      } else {
+        setNotice(payload.status === "PLAYER_WIN" ? "戰鬥勝利！" : "成功脫離戰場。");
+        setNoticeKind(null);
+      }
       setBattleId(null);
       setBattleState(null);
       api.getWorld(worldId).then(setSnapshot).catch(() => undefined);

--- a/azure-voyage/apps/web/src/game/PortCutscene.tsx
+++ b/azure-voyage/apps/web/src/game/PortCutscene.tsx
@@ -4,11 +4,14 @@ import { useEffect } from "react";
 import { generatePortSilhouette, portById } from "@azure-voyage/shared";
 
 export interface CutsceneState {
-  kind: "depart" | "arrival";
+  kind: "depart" | "arrival" | "defeat";
   portId: string;
   day: number;
   /** 僅入港過場帶：自出港以來的統計，前端自行累計，不需後端改動 */
   summary?: { days: number; food: number; water: number; events: number };
+  /** 僅戰敗過場帶：被拖回母港時扣的贖金（bug 修復：讓戰敗有明確、不易錯過的回饋，
+   * 不再只靠一閃即逝的通知，玩家才不會誤以為「無緣無故被傳回起始城市」） */
+  ransom?: number;
 }
 
 interface PortCutsceneProps {
@@ -19,6 +22,7 @@ interface PortCutsceneProps {
 
 const DEPART_MS = 2500;
 const ARRIVAL_MS = 2000;
+const DEFEAT_MS = 3500;
 
 /**
  * 港口進出過場（docs/10 §M13）：純 React overlay + CSS 動畫，零美術資產。
@@ -28,7 +32,7 @@ const ARRIVAL_MS = 2000;
 export function PortCutscene({ state, onDone, onSkipForever }: PortCutsceneProps) {
   const port = portById(state.portId);
   const silhouette = generatePortSilhouette(state.portId, port.size);
-  const duration = state.kind === "depart" ? DEPART_MS : ARRIVAL_MS;
+  const duration = state.kind === "depart" ? DEPART_MS : state.kind === "defeat" ? DEFEAT_MS : ARRIVAL_MS;
 
   useEffect(() => {
     const timer = setTimeout(onDone, duration);
@@ -82,22 +86,35 @@ export function PortCutscene({ state, onDone, onSkipForever }: PortCutsceneProps
 
       <svg
         viewBox="0 0 24 10"
-        className={
-          "h-10 w-24 " + (state.kind === "depart" ? "cutscene-ship-depart" : "cutscene-ship-arrive")
-        }
+        className={"h-10 w-24 " + (state.kind === "depart" ? "cutscene-ship-depart" : "cutscene-ship-arrive")}
       >
-        <polygon points="1,5 9,2.4 21,5 9,7.6" fill="#7a5230" stroke="#3a2716" strokeWidth={0.4} />
+        <polygon
+          points="1,5 9,2.4 21,5 9,7.6"
+          fill={state.kind === "defeat" ? "#4a2a2a" : "#7a5230"}
+          stroke="#3a2716"
+          strokeWidth={0.4}
+        />
       </svg>
 
       <div className="mt-6 text-center">
-        <h2 className="text-2xl font-bold text-gold">{port.name}</h2>
+        <h2 className={"text-2xl font-bold " + (state.kind === "defeat" ? "text-red-400" : "text-gold")}>
+          {port.name}
+        </h2>
         <p className="mt-1 text-slate-300">
-          第 {state.day} 日 {state.kind === "depart" ? "啟航" : "抵達"}
+          第 {state.day} 日{" "}
+          {state.kind === "depart" ? "啟航" : state.kind === "defeat" ? "戰敗，艦隊被拖回母港療傷" : "抵達"}
         </p>
         {state.kind === "arrival" && state.summary && (
           <p className="mt-2 text-sm text-slate-400">
             航行 {state.summary.days} 天 · 消耗糧 {state.summary.food}／水 {state.summary.water}
             {state.summary.events > 0 ? ` · 途中發生 ${state.summary.events} 起事件` : ""}
+          </p>
+        )}
+        {state.kind === "defeat" && (
+          <p className="mt-2 text-sm text-slate-400">
+            {state.ransom !== undefined && state.ransom > 0
+              ? `商會支付了 ${state.ransom.toLocaleString()} 金幣贖金，船隻已就地搶修完畢`
+              : "船隻已就地搶修完畢"}
           </p>
         )}
       </div>

--- a/azure-voyage/docs/20-defeat-feedback.md
+++ b/azure-voyage/docs/20-defeat-feedback.md
@@ -1,0 +1,70 @@
+# 20 — 戰敗回饋改善（對應 bug 回報：離開遊戲後回到起始城市）
+
+> 對應真實回報：「不管我到哪一個城市，跳出遊戲在進入遊戲之後，都會出現在初始城市
+> 裡面」。深入排查後，這不是資料錯亂／存檔重置 bug，而是刻意設計的戰敗懲罰機制
+> （`battle.service.ts` 打輸海戰會被拖回母港＋扣贖金）回饋做得不夠明確所致。
+
+## 0. 根本原因
+
+`BattleService.resolveBattleEnd()` 在 `PLAYER_LOSE` 時本來就會把艦隊強制傳送回
+`HOME_PORT_ID` 並扣一筆贖金——這是設計好的懲罰，不管玩家本來要航向哪個城市，
+打輸了都會被送回起始港口，跟目的地無關，完全符合回報描述的症狀。
+
+問題出在回饋管道：這件事發生時，前端只丟一個一閃即逝的 `notice` 小通知
+（「艦隊戰敗，被拖回母港療傷……」），非常容易被忽略，尤其是切分頁、視窗不在
+前景，或是疊加上 docs/19 那個「海戰凍結」bug（修復前玩家常常根本看不到海戰在
+進行）——等於完全沒感覺到自己「正在打」也不知道「打輸了」，直接跳到下次打開
+遊戲才發現艦隊已經在起始城市，感覺像無緣無故被重置。
+
+## 1. 修復設計
+
+**`packages/shared/src/schemas/battle.ts`**：
+
+- `ServerBattleEndSchema` 新增 `ransom: z.number().int().optional()`——只有
+  `PLAYER_LOSE` 會帶這個值，供前端過場畫面顯示扣了多少贖金。
+
+**`apps/api/src/modules/battle/battle.service.ts`**：
+
+- `resolveBattleEnd()` 回傳值從 `void` 改成 `number | undefined`：`PLAYER_LOSE`
+  時回傳實際扣除的贖金金額，`PLAYER_WIN`／`FLED` 回傳 `undefined`。
+- `applyAction()` 把這個回傳值一併放進 `BATTLE_END` 事件的 payload。
+
+**前端（`apps/web/src/game/PortCutscene.tsx` / `apps/web/src/app/play/[worldId]/page.tsx`）**：
+
+- `CutsceneState` 新增 `kind: "defeat"` 與 `ransom?: number`。
+- `PortCutscene` 新增戰敗過場的顯示：紅色標題、「戰敗，艦隊被拖回母港療傷」、
+  贖金金額（若 >0），停留時間拉長到 3.5 秒（`DEFEAT_MS`），比抵港過場（2 秒）
+  久，讓玩家有足夠時間看清楚發生了什麼事。
+- `BATTLE_END` 事件處理：`PLAYER_LOSE` 時不再只丟 `notice`，改成跟抵港一樣
+  明確、不可略過的全螢幕過場畫面（**不**受「不再顯示這個動畫」設定影響——
+  這是會改變艦隊位置與資金的重要狀態變化，不是單純的氣氛動畫，不應該被
+  略過）；`PLAYER_WIN`／`FLED` 維持原本的 `notice` 小通知。
+
+## 2. 不動的部分
+
+- 戰敗懲罰機制本身（拖回母港＋扣贖金比例 `DEFEAT_RANSOM_RATIO`）不變——這次
+  只修回饋是否清楚，不是覺得懲罰機制設計錯誤。
+- docs/19 的海戰重新連線修復不變；兩者疊加後，玩家現在無論是「正在打」還是
+  「錯過推播後重新連線接回戰鬥」，都能清楚看到戰鬥發生與結果。
+
+## 3. 測試
+
+- `apps/api/src/modules/battle/battle.service.spec.ts` 新增：建構「玩家血量僅剩
+  1、敵方血量健康」的確定性情境（玩家 MOVE 不回血，敵方 AI 血量健康時必定
+  `FIRE`、傷害保底至少 1 點），驗證 `PLAYER_LOSE` 時：狀態正確、商會資金確實
+  減少、艦隊確實被送回 `HOME_PORT_ID`、`BATTLE_END` 事件的 payload 帶有正確的
+  `ransom` 金額。
+- 真實環境端對端驗證（本機 Postgres + Redis + 真實 API/web server +
+  Playwright）：註冊帳號、建立世界、在 DB 插入一場玩家血量僅剩 1 的
+  `ONGOING` 海戰（帶 `fleetId`，重現「錯過即時推播」情境）、重新整理接回
+  戰鬥畫面、在畫面上實際點擊「移動」→ 填入座標 →「執行」送出真實的
+  `BATTLE_ACTION`，確認：
+  - 敵方自動開火擊沉玩家船，戰鬥正確判定 `PLAYER_LOSE`；
+  - 前端顯示紅色戰敗過場畫面：「奧雷利亞」「第 0 日 戰敗，艦隊被拖回母港
+    療傷」「商會支付了 1,000 金幣贖金，船隻已就地搶修完畢」；
+  - 過場結束後，資料庫確認艦隊 `dockedPortId` 為母港、`activity=DOCKED`，
+    商會資金從 10,000 正確扣至 9,000。
+
+既有的 API 全部測試（19 個 suite、147 個測試，含本次新增的 1 則）、
+`@azure-voyage/shared` 全部測試（22 個檔案、157 個測試）、API/web
+`tsc --noEmit`、`next build` 全數維持綠燈。

--- a/azure-voyage/packages/shared/src/schemas/battle.ts
+++ b/azure-voyage/packages/shared/src/schemas/battle.ts
@@ -70,5 +70,7 @@ export type ServerBattleUpdatePayload = z.infer<typeof ServerBattleUpdateSchema>
 export const ServerBattleEndSchema = z.object({
   battleId: z.string(),
   status: BattleStatusSchema,
+  /** 僅 PLAYER_LOSE 會帶：艦隊被拖回母港時扣的贖金，供前端過場畫面顯示 */
+  ransom: z.number().int().optional(),
 });
 export type ServerBattleEndPayload = z.infer<typeof ServerBattleEndSchema>;


### PR DESCRIPTION
## 摘要

- 對應 production bug 回報：「不管我到哪一個城市，跳出遊戲在進入遊戲之後，都
  會出現在初始城市裡面」。
- 深入排查後確認：這不是資料錯亂／存檔重置 bug，而是刻意設計的戰敗懲罰機制
  （`battle.service.ts`：打輸海戰會被拖回母港＋扣贖金）回饋不夠明確，容易被
  忽略或切分頁錯過，加上前次 PR #43 修好之前的海戰凍結 bug，玩家常常根本不知
  道自己正在打、打輸了，只看到艦隊「無緣無故」回到起始城市。
- 修法：`ServerBattleEndSchema` 新增 `ransom`；`BattleService` 回傳並推播實際
  扣除的贖金；前端把戰敗改成跟入港一樣明確、不可略過的全螢幕過場畫面（顯示
  「戰敗，艦隊被拖回母港療傷」與贖金金額），取代原本容易被忽略的一閃即逝
  通知。
- 詳見 `docs/20-defeat-feedback.md`。

## 測試

- [x] `apps/api`：全部 19 個測試檔、147 個測試通過（新增一則確定性重現
      `PLAYER_LOSE` 並驗證贖金/送回母港的測試）。
- [x] `@azure-voyage/shared`：全部 22 個測試檔、157 個測試通過。
- [x] `apps/api` / `apps/web`：`tsc --noEmit` 皆通過。
- [x] `apps/web`：`next build` 通過。
- [x] 真實環境端對端驗證：本機 Postgres + Redis + 真實 API/web server +
      Playwright，在 DB 插入一場「玩家血量僅剩 1、敵方血量健康」的進行中海戰
      （模擬錯過即時推播），重新整理接回戰鬥畫面後，實際在 UI 上點擊「移動」
      →「執行」送出真實 `BATTLE_ACTION`，確認敵方自動開火擊沉玩家、正確顯示
      紅色戰敗過場畫面與贖金金額，且資料庫確認艦隊被送回母港、資金正確扣除。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013kDwmPmYtbENLcfMzDdnNF

---
_Generated by [Claude Code](https://claude.ai/code/session_013kDwmPmYtbENLcfMzDdnNF)_