### PR TITLE
M31：真實失敗循環（破產 DEFEAT 狀態）

### DIFF
--- a/azure-voyage/apps/api/prisma/migrations/20260713155146_bankruptcy_defeat/migration.sql
+++ b/azure-voyage/apps/api/prisma/migrations/20260713155146_bankruptcy_defeat/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "GameWorld" ADD COLUMN     "bankruptTicks" INTEGER NOT NULL DEFAULT 0;

--- a/azure-voyage/apps/api/prisma/schema.prisma
+++ b/azure-voyage/apps/api/prisma/schema.prisma
@@ -46,6 +46,10 @@ model GameWorld {
   // 等於陣列長度時代表全部完成。條件判定全走既有可查詢狀態，這裡只存進度指標。
   questChapter Int @default(0)
 
+  // 破產寬限期計數（M31）：商會資金 <=0 且全部艦隊只剩最後一艘船時逐 tick 累加，
+  // 未持續達標則歸零；達到 BALANCE.BANKRUPTCY_GRACE_TICKS 才正式判定 DEFEAT。
+  bankruptTicks Int @default(0)
+
   guilds       Guild[]
   fleets       Fleet[]
   officers     Officer[]

--- a/azure-voyage/apps/api/src/gateway/game.gateway.ts
+++ b/azure-voyage/apps/api/src/gateway/game.gateway.ts
@@ -180,6 +180,11 @@ export class GameGateway implements OnGatewayConnection {
     this.server.to(worldRoom(worldId)).emit(WS_EVENTS.SERVER_QUEST_CHAPTER, payload);
   }
 
+  @OnEvent("world.defeat")
+  onWorldDefeat({ worldId, payload }: { worldId: string; payload: unknown }): void {
+    this.server.to(worldRoom(worldId)).emit(WS_EVENTS.SERVER_DEFEAT, payload);
+  }
+
   private requireUser(socket: Socket): string {
     const userId = (socket.data as Partial<GameSocketData>).userId;
     if (!userId) {

--- a/azure-voyage/apps/api/src/modules/clock/clock.module.ts
+++ b/azure-voyage/apps/api/src/modules/clock/clock.module.ts
@@ -2,6 +2,7 @@ import { Module } from "@nestjs/common";
 import { BullModule } from "@nestjs/bullmq";
 import { AiModule } from "../ai/ai.module";
 import { BattleModule } from "../battle/battle.module";
+import { DefeatModule } from "../defeat/defeat.module";
 import { EventModule } from "../event/event.module";
 import { InfluenceModule } from "../influence/influence.module";
 import { MarketModule } from "../market/market.module";
@@ -27,6 +28,7 @@ import { WORLD_TICK_QUEUE, WorldTickProcessor } from "./world-tick.processor";
     NpcModule,
     VictoryModule,
     QuestModule,
+    DefeatModule,
     AiModule,
   ],
   providers: [ClockService, WorldTickProcessor],

--- a/azure-voyage/apps/api/src/modules/clock/world-tick.processor.ts
+++ b/azure-voyage/apps/api/src/modules/clock/world-tick.processor.ts
@@ -5,6 +5,7 @@ import { EventGenService } from "../ai/event-gen.service";
 import { NpcStrategyService } from "../ai/npc-strategy.service";
 import { PersonaService } from "../ai/persona.service";
 import { EncounterService } from "../battle/encounter.service";
+import { DefeatService } from "../defeat/defeat.service";
 import { EventService } from "../event/event.service";
 import { InfluenceService } from "../influence/influence.service";
 import { EconomyService } from "../market/economy.service";
@@ -38,6 +39,7 @@ export class WorldTickProcessor extends WorkerHost {
     private readonly influenceService: InfluenceService,
     private readonly victoryService: VictoryService,
     private readonly questService: QuestService,
+    private readonly defeatService: DefeatService,
     private readonly npcStrategyService: NpcStrategyService,
     private readonly eventGenService: EventGenService,
     private readonly personaService: PersonaService,
@@ -63,6 +65,7 @@ export class WorldTickProcessor extends WorkerHost {
       await this.influenceService.settleAllPorts(worldId);
       await this.victoryService.checkVictory(worldId, last.tick);
       await this.questService.checkProgress(worldId, last.tick);
+      await this.defeatService.checkDefeat(worldId, last.tick);
     }
     return last!;
   }

--- a/azure-voyage/apps/api/src/modules/defeat/defeat.module.ts
+++ b/azure-voyage/apps/api/src/modules/defeat/defeat.module.ts
@@ -1,0 +1,8 @@
+import { Module } from "@nestjs/common";
+import { DefeatService } from "./defeat.service";
+
+@Module({
+  providers: [DefeatService],
+  exports: [DefeatService],
+})
+export class DefeatModule {}

--- a/azure-voyage/apps/api/src/modules/defeat/defeat.service.spec.ts
+++ b/azure-voyage/apps/api/src/modules/defeat/defeat.service.spec.ts
@@ -1,0 +1,116 @@
+import { EventEmitter2 } from "@nestjs/event-emitter";
+import { BALANCE } from "@azure-voyage/shared";
+import type { PrismaService } from "../../prisma/prisma.service";
+import { DefeatService, WORLD_DEFEAT_EVENT } from "./defeat.service";
+
+function makePrisma(opts: { status?: string; gold?: number; shipCount?: number; bankruptTicks?: number }) {
+  const world = {
+    id: "w1",
+    status: opts.status ?? "ACTIVE",
+    bankruptTicks: opts.bankruptTicks ?? 0,
+  };
+  const guild = { id: "g-player", worldId: "w1", kind: "PLAYER", gold: BigInt(opts.gold ?? 10000) };
+
+  const worldUpdateSpy = jest.fn(async ({ data }: { data: Partial<typeof world> }) => {
+    Object.assign(world, data);
+    return world;
+  });
+
+  const prisma = {
+    gameWorld: {
+      findUniqueOrThrow: jest.fn(async () => world),
+      update: worldUpdateSpy,
+    },
+    guild: {
+      findFirstOrThrow: jest.fn(async () => guild),
+    },
+    ship: {
+      count: jest.fn(async () => opts.shipCount ?? 3),
+    },
+  } as unknown as PrismaService;
+
+  return { prisma, world, guild, worldUpdateSpy };
+}
+
+describe("DefeatService.checkDefeat", () => {
+  it("does nothing when the guild is solvent", async () => {
+    const { prisma, world, worldUpdateSpy } = makePrisma({ gold: 5000, shipCount: 3 });
+    const service = new DefeatService(prisma, new EventEmitter2());
+
+    await service.checkDefeat("w1", 10);
+
+    expect(world.status).toBe("ACTIVE");
+    expect(worldUpdateSpy).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when broke but the fleet still has multiple ships", async () => {
+    const { prisma, world, worldUpdateSpy } = makePrisma({ gold: 0, shipCount: 2 });
+    const service = new DefeatService(prisma, new EventEmitter2());
+
+    await service.checkDefeat("w1", 10);
+
+    expect(world.status).toBe("ACTIVE");
+    expect(worldUpdateSpy).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when down to the last ship but still solvent", async () => {
+    const { prisma, world, worldUpdateSpy } = makePrisma({ gold: 100, shipCount: 1 });
+    const service = new DefeatService(prisma, new EventEmitter2());
+
+    await service.checkDefeat("w1", 10);
+
+    expect(world.status).toBe("ACTIVE");
+    expect(worldUpdateSpy).not.toHaveBeenCalled();
+  });
+
+  it("increments bankruptTicks while broke-and-last-ship persists, below the grace period", async () => {
+    const { prisma, world } = makePrisma({ gold: 0, shipCount: 1, bankruptTicks: 5 });
+    const service = new DefeatService(prisma, new EventEmitter2());
+
+    await service.checkDefeat("w1", 10);
+
+    expect(world.status).toBe("ACTIVE");
+    expect(world.bankruptTicks).toBe(6);
+  });
+
+  it("resets bankruptTicks to 0 once the guild recovers", async () => {
+    const { prisma, world, worldUpdateSpy } = makePrisma({ gold: 500, shipCount: 2, bankruptTicks: 12 });
+    const service = new DefeatService(prisma, new EventEmitter2());
+
+    await service.checkDefeat("w1", 10);
+
+    expect(world.bankruptTicks).toBe(0);
+    expect(worldUpdateSpy).toHaveBeenCalledWith({ where: { id: "w1" }, data: { bankruptTicks: 0 } });
+  });
+
+  it("declares DEFEAT once the grace period is exhausted", async () => {
+    const { prisma, world } = makePrisma({
+      gold: 0,
+      shipCount: 1,
+      bankruptTicks: BALANCE.BANKRUPTCY_GRACE_TICKS - 1,
+    });
+    const events = new EventEmitter2();
+    const emitSpy = jest.spyOn(events, "emit");
+    const service = new DefeatService(prisma, events);
+
+    await service.checkDefeat("w1", 42);
+
+    expect(world.status).toBe("DEFEAT");
+    expect(emitSpy).toHaveBeenCalledWith(
+      WORLD_DEFEAT_EVENT,
+      expect.objectContaining({
+        worldId: "w1",
+        payload: expect.objectContaining({ status: "DEFEAT", reason: "BANKRUPTCY", tick: 42 }),
+      }),
+    );
+  });
+
+  it("skips worlds that are no longer ACTIVE", async () => {
+    const { prisma, worldUpdateSpy } = makePrisma({ status: "VICTORY", gold: 0, shipCount: 1 });
+    const service = new DefeatService(prisma, new EventEmitter2());
+
+    await service.checkDefeat("w1", 10);
+
+    expect(worldUpdateSpy).not.toHaveBeenCalled();
+  });
+});

--- a/azure-voyage/apps/api/src/modules/defeat/defeat.service.ts
+++ b/azure-voyage/apps/api/src/modules/defeat/defeat.service.ts
@@ -1,0 +1,58 @@
+import { Injectable } from "@nestjs/common";
+import { EventEmitter2 } from "@nestjs/event-emitter";
+import { BALANCE, type ServerDefeatPayload } from "@azure-voyage/shared";
+import { PrismaService } from "../../prisma/prisma.service";
+
+export const WORLD_DEFEAT_EVENT = "world.defeat";
+
+export interface WorldDefeatEventPayload {
+  worldId: string;
+  payload: ServerDefeatPayload;
+}
+
+/**
+ * 破產判定（M31，docs/25）：docs/01 §2 原始設計的失敗條件（「破產：現金 < 0
+ * 且無船可賣」「旗艦沉沒且無力再購船」）在現有規則下其實不可達——全系統的
+ * 金流路徑都刻意設計成不會讓資金變負值（INSUFFICIENT_GOLD 檢查、欠薪走忠誠度
+ * 懲罰而非硬扣、戰敗贖金上限抓現有資金比例……），賣船/分艦也都保底至少留一艘
+ * 船（CANNOT_SELL_LAST_SHIP／CANNOT_SPLIT_ALL_SHIPS）。
+ *
+ * 這裡用「資金 <=0 且全部艦隊合計只剩最後一艘船」作為對應原始設計精神的可達成
+ * 判定條件：持續達到寬限期（BANKRUPTCY_GRACE_TICKS）才正式判定 DEFEAT，讓玩家
+ * 有機會在寬限期內翻本（賣貨、發現物、探索……）而不是無預警結束。
+ */
+@Injectable()
+export class DefeatService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly events: EventEmitter2,
+  ) {}
+
+  async checkDefeat(worldId: string, tick: number): Promise<void> {
+    const world = await this.prisma.gameWorld.findUniqueOrThrow({ where: { id: worldId } });
+    if (world.status !== "ACTIVE") return;
+
+    const guild = await this.prisma.guild.findFirstOrThrow({ where: { worldId, kind: "PLAYER" } });
+    const shipCount = await this.prisma.ship.count({
+      where: { fleet: { worldId, guildId: guild.id } },
+    });
+    const isBroke = Number(guild.gold) <= 0 && shipCount <= 1;
+
+    if (!isBroke) {
+      if (world.bankruptTicks > 0) {
+        await this.prisma.gameWorld.update({ where: { id: worldId }, data: { bankruptTicks: 0 } });
+      }
+      return;
+    }
+
+    const bankruptTicks = world.bankruptTicks + 1;
+    if (bankruptTicks < BALANCE.BANKRUPTCY_GRACE_TICKS) {
+      await this.prisma.gameWorld.update({ where: { id: worldId }, data: { bankruptTicks } });
+      return;
+    }
+
+    await this.prisma.gameWorld.update({ where: { id: worldId }, data: { status: "DEFEAT" } });
+    const payload: ServerDefeatPayload = { status: "DEFEAT", tick, reason: "BANKRUPTCY" };
+    this.events.emit(WORLD_DEFEAT_EVENT, { worldId, payload } satisfies WorldDefeatEventPayload);
+  }
+}

--- a/azure-voyage/apps/api/src/modules/world/world.service.ts
+++ b/azure-voyage/apps/api/src/modules/world/world.service.ts
@@ -296,9 +296,14 @@ export class WorldService {
     const dockedPortIds = new Set(
       fleets.map((f) => f.dockedPortId).filter((p): p is string => p !== null),
     );
-    const shipValue = fleets
-      .flatMap((f) => f.ships)
-      .reduce((acc, s) => acc + shipClassById(s.shipClassId).price, 0);
+    const allShips = fleets.flatMap((f) => f.ships);
+    const shipValue = allShips.reduce((acc, s) => acc + shipClassById(s.shipClassId).price, 0);
+    // M31：破產倒數警示——資金 <=0 且全部艦隊只剩最後一艘船時才顯示，讓玩家
+    // 看得到寬限期倒數（見 DefeatService 的判定邏輯，這裡只是唯讀呈現）。
+    const bankruptcyWarning =
+      Number(playerGuild.gold) <= 0 && allShips.length <= 1
+        ? { ticksElapsed: world.bankruptTicks, graceTicks: BALANCE.BANKRUPTCY_GRACE_TICKS }
+        : null;
     const regionsDominated = regionsDominatedBy(
       playerGuild.id,
       influenceRows.map((r) => ({ portId: r.portState.portId, guildId: r.guildId, share: Number(r.share) })),
@@ -391,6 +396,7 @@ export class WorldService {
         totalAssets: Number(playerGuild.gold) + shipValue,
       },
       quest: buildQuestProgressView(world.questChapter),
+      bankruptcyWarning,
     };
     // 驗收要求：快照必須通過 shared zod schema（docs/09 M1）
     return WorldSnapshotSchema.parse(snapshot);

--- a/azure-voyage/apps/web/src/app/play/[worldId]/page.tsx
+++ b/azure-voyage/apps/web/src/app/play/[worldId]/page.tsx
@@ -32,6 +32,7 @@ import {
   type ServerQuestChapterPayload,
   type ServerResyncPayload,
   type ServerTickPayload,
+  type ServerDefeatPayload,
   type ServerVictoryPayload,
   type WorldSnapshot,
 } from "@azure-voyage/shared";
@@ -107,6 +108,13 @@ const VICTORY_REASON_LABELS: Record<ServerVictoryPayload["reason"], string> = {
   ASSET_TARGET: "累積總資產",
   RELIC_COLLECTOR: "傳世遺物蒐集",
 };
+/** M31：破產結局的原創收尾敘事（唯一的失敗原因目前只有 BANKRUPTCY） */
+const DEFEAT_REASON_NARRATIVE: Record<ServerDefeatPayload["reason"], string> = {
+  BANKRUPTCY:
+    "帳房最後一次點清金庫，只剩下滿地的欠條。碼頭上，債主們的身影比海鷗還多。" +
+    "最後一艘船靜靜停在原本屬於你的泊位——蒼瀾海域不會等一個破產的商會東山再起，" +
+    "這段航路，到此為止。",
+};
 /** M14：天氣標籤與顏色 */
 const WEATHER_LABELS: Record<string, { text: string; cls: string }> = {
   CLEAR: { text: "晴朗", cls: "text-slate-300" },
@@ -138,6 +146,7 @@ export default function PlayPage() {
   const [battleState, setBattleState] = useState<BattleStateView | null>(null);
   const [battleLog, setBattleLog] = useState<string[]>([]);
   const [victory, setVictory] = useState<ServerVictoryPayload | null>(null);
+  const [defeat, setDefeat] = useState<ServerDefeatPayload | null>(null);
   const [cutscene, setCutscene] = useState<CutsceneState | null>(null);
   const [codexOpen, setCodexOpen] = useState(false);
   const [captainOpen, setCaptainOpen] = useState(false);
@@ -301,6 +310,9 @@ export default function PlayPage() {
     socket.on(WS_EVENTS.SERVER_VICTORY, (payload: ServerVictoryPayload) => {
       setVictory(payload);
     });
+    socket.on(WS_EVENTS.SERVER_DEFEAT, (payload: ServerDefeatPayload) => {
+      setDefeat(payload);
+    });
     socket.on(WS_EVENTS.SERVER_QUEST_CHAPTER, (payload: ServerQuestChapterPayload) => {
       setQuestCutscene(payload);
       api.getWorld(worldId).then(setSnapshot).catch(() => undefined);
@@ -396,7 +408,9 @@ export default function PlayPage() {
     if (activity === "DOCKED") setPendingHeading(null);
   }, [activity]);
   // 重新整理頁面時若世界早已結束（例如先前已達成勝利），仍要顯示終局畫面
-  const gameEnded = victory !== null || (snapshot ? snapshot.world.status !== "ACTIVE" : false);
+  // M31：DEFEAT 是獨立於 VICTORY 的結局，不能沿用同一塊「商會稱霸四海」畫面
+  const isDefeat = defeat !== null || (snapshot ? snapshot.world.status === "DEFEAT" : false);
+  const gameEnded = victory !== null || isDefeat || (snapshot ? snapshot.world.status !== "ACTIVE" : false);
 
   // ── 節奏器：SAILING 時依速度檔每隔 N ms 送出 client:advance ──
   // M13：過場動畫期間暫停（與「暫停」檔語意一致，無資料面副作用）。
@@ -704,15 +718,34 @@ export default function PlayPage() {
       )}
 
       {gameEnded && (
-        <section className="panel border-2 border-gold bg-gold/10 text-center">
-          <h2 className="text-2xl font-bold text-gold">
-            商會稱霸四海！
-            {victory ? `第 ${victory.tick} 日達成勝利` : ""}
-          </h2>
-          {victory && (
-            <p className="mt-1 text-sm text-slate-300">
-              {VICTORY_REASON_LABELS[victory.reason]}達成勝利條件。
-            </p>
+        <section
+          className={
+            isDefeat
+              ? "panel border-2 border-red-500/70 bg-red-950/20 text-center"
+              : "panel border-2 border-gold bg-gold/10 text-center"
+          }
+        >
+          {isDefeat ? (
+            <>
+              <h2 className="text-2xl font-bold text-red-400">
+                商會傾覆……{defeat ? `第 ${defeat.tick} 日` : ""}
+              </h2>
+              <p className="mt-1 text-sm text-slate-300">
+                {DEFEAT_REASON_NARRATIVE[defeat?.reason ?? "BANKRUPTCY"]}
+              </p>
+            </>
+          ) : (
+            <>
+              <h2 className="text-2xl font-bold text-gold">
+                商會稱霸四海！
+                {victory ? `第 ${victory.tick} 日達成勝利` : ""}
+              </h2>
+              {victory && (
+                <p className="mt-1 text-sm text-slate-300">
+                  {VICTORY_REASON_LABELS[victory.reason]}達成勝利條件。
+                </p>
+              )}
+            </>
           )}
           <Link href="/worlds" className="btn mt-3 inline-block">
             回航海誌
@@ -800,6 +833,14 @@ export default function PlayPage() {
               )
             )}
           </section>
+
+          {snapshot.bankruptcyWarning && (
+            <section className="panel border border-red-500/60 bg-red-950/20 py-2 text-sm text-red-300">
+              瀕臨破產！資金見底、艦隊只剩最後一艘船——若持續{" "}
+              {snapshot.bankruptcyWarning.graceTicks - snapshot.bankruptcyWarning.ticksElapsed} 天沒有翻本，
+              商會將宣告破產。快去交易或探索找機會回本。
+            </section>
+          )}
 
           {codexOpen && <DiscoveryCodexPanel worldId={worldId} onClose={() => setCodexOpen(false)} />}
           {captainOpen && (

--- a/azure-voyage/docs/25-real-failure-loop.md
+++ b/azure-voyage/docs/25-real-failure-loop.md
@@ -1,0 +1,81 @@
+# 25 — M31：真實失敗循環（破產 DEFEAT 狀態）
+
+> 使用者要求的「真實失敗循環」。深入排查後發現 docs/01 §2 原始設計的失敗
+> 條件（「破產：現金 < 0 且無船可賣」「旗艦沉沒且無力再購船」）在現有規則下
+> 其實**結構性不可達**——不是漏做判定，而是全系統的金流路徑都刻意設計成
+> 不會讓資金變負值，賣船/分艦也都保底至少留一艘船。`WORLD_STATUSES` 雖然
+> 定義了 `DEFEAT`，但整個程式碼庫從沒有任何地方真正寫入過這個狀態；前端更
+> 只要 `status !== "ACTIVE"` 就顯示「商會稱霸四海！」的勝利畫面，DEFEAT
+> 真的發生時反而會顯示錯的訊息。
+
+## 1. 為什麼「現金 < 0」結構性不可達
+
+逐一檢查金流路徑：
+
+- 交易：`market.service.ts` 買入前檢查 `gold < total` 就丟 `INSUFFICIENT_GOLD`。
+- 薪資：`officer.service.ts#paySalariesIfDue` 付不起就走忠誠度懲罰，不硬扣。
+- 修理：`shipyard.service.ts#repair` 資金不夠就修到哪算哪，不會透支。
+- 出港補給：按可負擔比例補，不會透支。
+- 海戰贖金：只扣現有資金的固定比例（`DEFEAT_RANSOM_RATIO`），不會透支。
+- 賣船／分艦：`CANNOT_SELL_LAST_SHIP`／`CANNOT_SPLIT_ALL_SHIPS` 保底至少留
+  一艘船；海戰戰敗的 `forceSurvive` 邏輯保底艦隊不會歸零艘船。
+
+**結論**：現金永遠 ≥0、艦隊永遠 ≥1 艘船，是這個專案從 M2 到 M29 一路刻意維持
+的不變量，不是巧合。
+
+## 2. 判定條件：用可達成的絕境對應原始設計精神
+
+不去打破「現金不變負值」這個貫穿全系統的不變量（風險太高、牽動太多既有
+邏輯），改用**對應原始設計精神、但實際可達成**的絕境狀態：
+
+> 商會資金 ≤0，且名下全部艦隊合計只剩最後一艘船。
+
+`apps/api/src/modules/defeat/defeat.service.ts`（新模組，比照 `VictoryService`
+的結構）：`checkDefeat()` 每 tick 檢查這個條件——
+
+- 條件不成立：若 `bankruptTicks > 0` 就歸零（讓玩家翻本後倒數重置，不是
+  「曾經窮過一次就注定完蛋」）。
+- 條件成立：`bankruptTicks + 1`；未達 `BANKRUPTCY_GRACE_TICKS`（30）就只是
+  累加繼續等；達到才正式把 `GameWorld.status` 設成 `DEFEAT`，廣播
+  `world.defeat` domain event。
+
+**30 tick 的寬限期**是這次「真實失敗循環」的核心——不是絕境當下立刻結束，
+是給玩家一段真實的窗口去翻本（賣掉貨艙裡的存貨、去做一次發現物登錄、賭一把
+短程貿易）。這才是「循環」：陷入絕境 → 看得到倒數 → 有機會掙脫或真的沉沒。
+
+## 3. 玩家看得到倒數，不是無預警結束
+
+`WorldSnapshot` 新增 `bankruptcyWarning: { ticksElapsed, graceTicks } | null`
+（`world.service.ts#getSnapshot`，唯讀呈現，判定邏輯仍然只在 `DefeatService`
+一個地方）。前端在絕境成立時顯示醒目的紅色警示橫幅：「瀕臨破產！...若持續
+N 天沒有翻本，商會將宣告破產」，`N` 即時倒數。
+
+## 4. 修正既有 bug：DEFEAT 畫面被誤標成勝利
+
+`apps/web/src/app/play/[worldId]/page.tsx` 原本的結局畫面邏輯：
+
+```js
+const gameEnded = victory !== null || (snapshot ? snapshot.world.status !== "ACTIVE" : false);
+```
+
+只要世界不是 ACTIVE 就顯示同一塊寫死的「商會稱霸四海！」——這代表**萬一
+DEFEAT 真的發生過，畫面會顯示錯的訊息**（歡慶戰敗）。修正為區分
+`isDefeat`／勝利兩種結局，各自對應的原創收尾敘事與樣式（DEFEAT 用紅色邊框，
+VICTORY 維持金色）。
+
+## 5. 測試
+
+- `apps/api/src/modules/defeat/defeat.service.spec.ts`（新增，7 則）：資金
+  健康／破產但船數足夠／船數見底但資金健康——三種都不觸發；寬限期內累加、
+  翻本後歸零；達到寬限期正式判定 DEFEAT 並廣播正確 payload；非 ACTIVE 世界
+  不重複判定。
+- 真實環境端對端驗證（本機 Postgres + Redis + 真實 API/web server +
+  Playwright）：建立世界、直接把商會資金歸零、把 `bankruptTicks` 設到只差
+  2 tick 就達標，出港讓真實 tick pipeline 跑起來——確認重整後立刻看到「瀕臨
+  破產」警示橫幅（倒數 2 天），約 2 秒後（2 個真實 tick）畫面正確切換成獨立
+  的紅色「商會傾覆……第 2 日」結局畫面（而非誤標成勝利），資料庫
+  `GameWorld.status` 正確寫入 `DEFEAT`。
+
+既有的 API 全部測試（21 個 suite、170 個測試）、`@azure-voyage/shared` 全部
+測試（23 個檔案、168 個測試）、API/web `tsc --noEmit`、`next build` 全數維持
+綠燈。

--- a/azure-voyage/packages/shared/src/content/constants.ts
+++ b/azure-voyage/packages/shared/src/content/constants.ts
@@ -179,6 +179,11 @@ export const BALANCE = {
   /** 傳世遺物（S 級發現物）蒐集勝利門檻：登錄滿此數即達成（M22，docs/01 §2 執行記錄） */
   VICTORY_RELICS_REQUIRED: 3,
 
+  // ── 失敗條件（M31，docs/01 §2、docs/25）──
+  /** 破產寬限期（tick）：商會資金 <=0 且全部艦隊合計只剩最後一艘船，連續達到
+   * 這麼多 tick 才正式判定 DEFEAT——給玩家時間翻本，而不是一次判定就結束。 */
+  BANKRUPTCY_GRACE_TICKS: 30,
+
   // ── 存檔 ──
   MAX_ACTIVE_WORLDS_PER_USER: 5,
 

--- a/azure-voyage/packages/shared/src/schemas/schemas.test.ts
+++ b/azure-voyage/packages/shared/src/schemas/schemas.test.ts
@@ -112,6 +112,7 @@ describe("world schemas", () => {
       ],
       npcGuilds: [{ id: "g2", name: "霜港同盟", color: "#7fb8d4", fame: 0 }],
       victoryProgress: { regionsDominated: 0, relicsFound: 0, totalAssets: 10000 },
+      bankruptcyWarning: null,
       quest: {
         chapterIndex: 0,
         totalChapters: 6,

--- a/azure-voyage/packages/shared/src/schemas/world.ts
+++ b/azure-voyage/packages/shared/src/schemas/world.ts
@@ -140,6 +140,16 @@ export const QuestProgressViewSchema = z.object({
 });
 export type QuestProgressView = z.infer<typeof QuestProgressViewSchema>;
 
+/**
+ * 破產倒數警示（M31）：商會目前處於「資金 <=0 且全部艦隊只剩最後一艘船」的
+ * 絕境時才非 null——讓玩家看得到寬限期倒數，有機會翻本，而不是無預警 DEFEAT。
+ */
+export const BankruptcyWarningViewSchema = z.object({
+  ticksElapsed: z.number().int(),
+  graceTicks: z.number().int(),
+});
+export type BankruptcyWarningView = z.infer<typeof BankruptcyWarningViewSchema>;
+
 export const WorldSnapshotSchema = z.object({
   world: WorldSummarySchema.extend({ seed: z.number().int() }),
   playerGuild: z.object({
@@ -158,5 +168,6 @@ export const WorldSnapshotSchema = z.object({
     relicsFound: z.number().int(),
     totalAssets: z.number().int(),
   }),
+  bankruptcyWarning: BankruptcyWarningViewSchema.nullable(),
 });
 export type WorldSnapshot = z.infer<typeof WorldSnapshotSchema>;

--- a/azure-voyage/packages/shared/src/schemas/ws.ts
+++ b/azure-voyage/packages/shared/src/schemas/ws.ts
@@ -21,6 +21,7 @@ export const WS_EVENTS = {
   BATTLE_END: "battle:end",
   SERVER_VICTORY: "server:victory",
   SERVER_QUEST_CHAPTER: "server:quest-chapter",
+  SERVER_DEFEAT: "server:defeat",
 } as const;
 
 export const ClientJoinSchema = z.object({
@@ -69,3 +70,11 @@ export const ServerQuestChapterSchema = z.object({
   fameReward: z.number().int(),
 });
 export type ServerQuestChapterPayload = z.infer<typeof ServerQuestChapterSchema>;
+
+/** 破產判定推播（M31）：目前唯一的失敗原因是破產，先留 enum 方便日後擴充。 */
+export const ServerDefeatSchema = z.object({
+  status: WorldStatusSchema,
+  tick: z.number().int().nonnegative(),
+  reason: z.enum(["BANKRUPTCY"]),
+});
+export type ServerDefeatPayload = z.infer<typeof ServerDefeatSchema>;


### PR DESCRIPTION
## 摘要

- docs/01 §2 原始設計的失敗條件（「破產：現金 < 0 且無船可賣」「旗艦沉沒且
  無力再購船」）在現有規則下**結構性不可達**——全系統金流路徑（交易/薪資/
  修理/補給/贖金）都刻意設計成不會讓資金變負值，賣船/分艦也都保底至少留
  一艘船。`WORLD_STATUSES` 雖然定義了 `DEFEAT`，但整個程式碼庫從沒有任何
  地方真正寫入過這個狀態。
- 新增 `DefeatService`：用「商會資金 <=0 且全部艦隊合計只剩最後一艘船」作為
  對應原始設計精神、但實際可達成的絕境判定，持續 30 tick（寬限期，讓玩家有
  機會翻本）才正式判定 DEFEAT。
- `WorldSnapshot` 新增破產倒數警示，前端顯示醒目橫幅，不是無預警結束——
  這才是「真實失敗**循環**」：陷入絕境 → 看得到倒數 → 有機會掙脫或真的沉沒。
- 順手修正既有 bug：結局畫面原本只要世界非 ACTIVE 就顯示「商會稱霸四海！」
  的勝利文案，DEFEAT 真的發生時會被誤標成勝利——現在有獨立的紅色戰敗畫面與
  原創收尾敘事。
- 詳見 `docs/25-real-failure-loop.md`。

## 測試

- [x] `apps/api`：全部 21 個測試檔、170 個測試通過（新增 `defeat.service.spec.ts`
      7 則）。
- [x] `@azure-voyage/shared`：全部 23 個測試檔、168 個測試通過。
- [x] `apps/api` / `apps/web`：`tsc --noEmit` 皆通過。
- [x] `apps/web`：`next build` 通過。
- [x] 真實環境端對端驗證：本機 Postgres + Redis + 真實 API/web server +
      Playwright，直接把商會資金歸零、把 `bankruptTicks` 設到只差 2 tick 就
      達標，出港讓真實 tick pipeline 運作——重整後立刻看到「瀕臨破產」倒數
      橫幅，約 2 個真實 tick 後畫面正確切換成獨立的紅色「商會傾覆」結局畫面
      （非誤標成勝利），資料庫 `GameWorld.status` 正確寫入 `DEFEAT`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013kDwmPmYtbENLcfMzDdnNF

---
_Generated by [Claude Code](https://claude.ai/code/session_013kDwmPmYtbENLcfMzDdnNF)_