### PR TITLE
M32：市場情報不完全（港口情報時效性）

### DIFF
--- a/azure-voyage/apps/api/prisma/migrations/20260713160610_port_intel/migration.sql
+++ b/azure-voyage/apps/api/prisma/migrations/20260713160610_port_intel/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "PortIntel" (
+    "id" TEXT NOT NULL,
+    "worldId" TEXT NOT NULL,
+    "portId" TEXT NOT NULL,
+    "lastVisitedTick" INTEGER NOT NULL,
+    "market" JSONB NOT NULL,
+
+    CONSTRAINT "PortIntel_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "PortIntel_worldId_idx" ON "PortIntel"("worldId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PortIntel_worldId_portId_key" ON "PortIntel"("worldId", "portId");
+
+-- AddForeignKey
+ALTER TABLE "PortIntel" ADD CONSTRAINT "PortIntel_worldId_fkey" FOREIGN KEY ("worldId") REFERENCES "GameWorld"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/azure-voyage/apps/api/prisma/schema.prisma
+++ b/azure-voyage/apps/api/prisma/schema.prisma
@@ -59,6 +59,7 @@ model GameWorld {
   battles      Battle[]
   discoveries  DiscoveryRecord[]
   aiLogs       AiGenerationLog[]
+  portIntel    PortIntel[]
 
   @@index([userId, status])
 }
@@ -215,6 +216,21 @@ model MarketStock {
   priceHistory Json      @default("[]") // [{t,p}] 環形陣列 max 60
 
   @@unique([portStateId, commodityId])
+}
+
+// 玩家對某港口市場的「已知情報」（M31→M32，市場情報不完全）：只在玩家實際
+// 停靠該港的當下更新一次快照，之後就是固定不變的舊情報，直到下次真的再去一趟。
+// 停靠期間時間不會前進（docs/01 §核心循環），所以「抵達當下」snapshot 一次即可。
+model PortIntel {
+  id              String    @id @default(cuid())
+  worldId         String
+  world           GameWorld @relation(fields: [worldId], references: [id], onDelete: Cascade)
+  portId          String // contentId
+  lastVisitedTick Int
+  market          Json // [{commodityId, buyPrice, sellPrice}]（抵達當下算好的有效買賣價，不隨後續影響力變動更新）
+
+  @@unique([worldId, portId])
+  @@index([worldId])
 }
 
 model PortInfluence {

--- a/azure-voyage/apps/api/src/modules/market/market.service.spec.ts
+++ b/azure-voyage/apps/api/src/modules/market/market.service.spec.ts
@@ -281,25 +281,32 @@ describe("MarketService.getTradeRouteSuggestions", () => {
   const TARGET_PORT_ID = "port.amber_gulf.mirenport";
 
   function makeTradeRoutePrisma() {
-    const world = { id: "w1", userId: "u1", status: "ACTIVE" };
+    const world = { id: "w1", userId: "u1", status: "ACTIVE", currentTick: 10 };
     const guild = { id: "g1", worldId: "w1", kind: "PLAYER" };
-    const portStates = [
+    const originState = {
+      portId: ORIGIN_PORT_ID,
+      market: [{ commodityId: "com.wine", price: 10, stock: 100, baseStock: 100 }],
+      influences: [] as { guildId: string; share: number }[],
+    };
+    // M32：非起點港只用玩家「已去過」留下的舊情報（PortIntel），不再讀即時市場
+    const intelRows = [
       {
-        portId: ORIGIN_PORT_ID,
-        market: [{ commodityId: "com.wine", price: 10, stock: 100, baseStock: 100 }],
-        influences: [] as { guildId: string; share: number }[],
-      },
-      {
+        worldId: "w1",
         portId: TARGET_PORT_ID,
-        market: [{ commodityId: "com.wine", price: 30, stock: 100, baseStock: 100 }],
-        influences: [] as { guildId: string; share: number }[],
+        lastVisitedTick: 8,
+        market: [{ commodityId: "com.wine", buyPrice: 27, sellPrice: 30 }],
       },
     ];
 
     const prisma = {
       gameWorld: { findUnique: jest.fn(async () => world) },
       guild: { findFirstOrThrow: jest.fn(async () => guild) },
-      portState: { findMany: jest.fn(async () => portStates) },
+      portState: {
+        findUnique: jest.fn(async ({ where }: { where: { worldId_portId: { portId: string } } }) =>
+          where.worldId_portId.portId === ORIGIN_PORT_ID ? originState : null,
+        ),
+      },
+      portIntel: { findMany: jest.fn(async () => intelRows) },
     } as unknown as PrismaService;
 
     return { prisma };
@@ -316,8 +323,19 @@ describe("MarketService.getTradeRouteSuggestions", () => {
       commodityId: "com.wine",
       buyPortId: ORIGIN_PORT_ID,
       sellPortId: TARGET_PORT_ID,
+      sellIntelAgeTicks: 2, // currentTick(10) - lastVisitedTick(8)
     });
     expect(suggestions[0].profitPerUnit).toBeGreaterThan(0);
+  });
+
+  it("excludes ports the player has never actually visited (no PortIntel row)", async () => {
+    const { prisma } = makeTradeRoutePrisma();
+    (prisma.portIntel.findMany as jest.Mock).mockResolvedValueOnce([]);
+    const service = new MarketService(prisma);
+
+    const suggestions = await service.getTradeRouteSuggestions("u1", "w1", ORIGIN_PORT_ID);
+
+    expect(suggestions).toHaveLength(0);
   });
 
   it("rejects an unknown origin port", async () => {

--- a/azure-voyage/apps/api/src/modules/market/market.service.ts
+++ b/azure-voyage/apps/api/src/modules/market/market.service.ts
@@ -91,10 +91,11 @@ export class MarketService {
   }
 
   /**
-   * 貿易路線建議（docs/01 §4.2、M24）：以 portId 為起點，比較全部港口目前的
-   * 有效買/賣價，算出「在起點買、去哪賣」的獲利建議，按「單位獲利/距離」排序。
-   * 只讀當下市場快照，不含 PURSER 職位加成（那是實際下單時才套用的折扣，
-   * 這裡單純是市場情報，維持跟 getPortDetail 一致的簡化）。
+   * 貿易路線建議（docs/01 §4.2、M24；M32 市場情報不完全）：以 portId 為起點，
+   * 起點港讀「即時」市場真相（玩家人就站在這裡）；其餘候選港只用玩家上次實際
+   * 抵達當下留下的舊情報（`PortIntel`）——從沒去過的港口沒有情報列，直接不
+   * 列入候選，不再是全地圖即時全知。不含 PURSER 職位加成（那是下單時才套用
+   * 的折扣，這裡單純是市場情報，維持跟 getPortDetail 一致的簡化）。
    */
   async getTradeRouteSuggestions(
     userId: string,
@@ -106,31 +107,41 @@ export class MarketService {
     if (!world || world.userId !== userId) throw new GameError("NOT_FOUND");
 
     const playerGuild = await this.prisma.guild.findFirstOrThrow({ where: { worldId, kind: "PLAYER" } });
-    // 只取現行 15 港（排除 M21 刪除後留下的孤兒 PortState，見 docs/13 §2）
-    const portStates = await this.prisma.portState.findMany({
-      where: { worldId, portId: { in: [...PORT_IDS] } },
+
+    const originState = await this.prisma.portState.findUnique({
+      where: { worldId_portId: { worldId, portId } },
       include: { market: true, influences: true },
     });
+    if (!originState) throw new GameError("NOT_FOUND");
+    const originPort = portById(originState.portId);
+    const originShare = Number(originState.influences.find((i) => i.guildId === playerGuild.id)?.share ?? 0);
+    const origin: PortMarketSnapshot = {
+      portId: originState.portId,
+      portName: originPort.name,
+      coord: originPort.coord,
+      listings: originState.market.map((m) => ({
+        commodityId: m.commodityId,
+        buyPrice: effectiveBuyPrice(m.price, originShare),
+        sellPrice: effectiveSellPrice(m.price, originShare),
+      })),
+    };
 
-    const snapshots: PortMarketSnapshot[] = portStates.map((ps) => {
-      const port = portById(ps.portId);
-      const share = Number(ps.influences.find((i) => i.guildId === playerGuild.id)?.share ?? 0);
+    // 只取現行 15 港（排除 M21 刪除後留下的孤兒 PortIntel，見 docs/13 §2）
+    const intelRows = await this.prisma.portIntel.findMany({
+      where: { worldId, portId: { in: PORT_IDS.filter((id) => id !== portId) } },
+    });
+    const candidates: PortMarketSnapshot[] = intelRows.map((intel) => {
+      const port = portById(intel.portId);
       return {
-        portId: ps.portId,
+        portId: intel.portId,
         portName: port.name,
         coord: port.coord,
-        listings: ps.market.map((m) => ({
-          commodityId: m.commodityId,
-          buyPrice: effectiveBuyPrice(m.price, share),
-          sellPrice: effectiveSellPrice(m.price, share),
-        })),
+        listings: intel.market as { commodityId: string; buyPrice: number; sellPrice: number }[],
+        intelAgeTicks: world.currentTick - intel.lastVisitedTick,
       };
     });
 
-    const origin = snapshots.find((s) => s.portId === portId);
-    if (!origin) throw new GameError("NOT_FOUND");
-
-    return bestTradeRoutesFrom(origin, snapshots, limit);
+    return bestTradeRoutesFrom(origin, [origin, ...candidates], limit);
   }
 
   /**

--- a/azure-voyage/apps/api/src/modules/voyage/voyage.service.spec.ts
+++ b/azure-voyage/apps/api/src/modules/voyage/voyage.service.spec.ts
@@ -126,6 +126,20 @@ function makePrismaMock(state: {
       findMany: jest.fn(async () => [] as { id: string; role: string | null; stats: unknown; exp: number }[]),
       update: jest.fn(),
     },
+    // M32：抵達港口時凍結市場情報（PortIntel）；測試不驗證這裡的內容細節，
+    // 只需要 portState 有市場資料可讀、portIntel.upsert 不會炸掉即可。
+    portState: {
+      findUnique: jest.fn(async () => ({
+        id: "ps1",
+        worldId: "w1",
+        portId: "port.any",
+        market: [{ commodityId: "com.wine", price: 10, stock: 100, baseStock: 100 }],
+        influences: [] as { guildId: string; share: number }[],
+      })),
+    },
+    portIntel: {
+      upsert: jest.fn(async () => ({})),
+    },
     $transaction: jest.fn(async (fn: (tx: unknown) => Promise<unknown>) => fn(prisma)),
   } as unknown as PrismaService;
   return { prisma, guild };

--- a/azure-voyage/apps/api/src/modules/voyage/voyage.service.ts
+++ b/azure-voyage/apps/api/src/modules/voyage/voyage.service.ts
@@ -6,6 +6,8 @@ import {
   BALANCE,
   captainNavSpeedBonus,
   consumeSupplies,
+  effectiveBuyPrice,
+  effectiveSellPrice,
   findPath,
   fleetSpeed,
   HEXMAP,
@@ -318,6 +320,7 @@ export class VoyageService {
         arrivals.push({ worldId, payload: { tick: newTick, fleetId: fleet.id, portId: arrivedPortId! } });
         await awardExpToFleetOfficers(this.prisma, fleet.id, BALANCE.OFFICER_EXP_PER_ARRIVAL);
         await awardCaptainExp(this.prisma, fleet.guildId, BALANCE.CAPTAIN_EXP_PER_ARRIVAL);
+        await this.recordPortIntel(worldId, arrivedPortId!, fleet.guildId, newTick);
       }
       if (anchoredAtSea) {
         notices.push(`「${fleet.name}」已抵達目標海域，下錨待命。`);
@@ -348,5 +351,34 @@ export class VoyageService {
       this.events.emit(WORLD_ARRIVAL_EVENT, arrival);
     }
     return tickPayload;
+  }
+
+  /**
+   * 抵達港口當下，把「此刻的有效買賣價」凍結存成該商會對這個港口的已知情報
+   * （M32，市場情報不完全）。停靠期間時間不會前進（docs/01 §核心循環），
+   * 抵達當下 snapshot 一次即可代表這次停靠所知道的全部；下次真的再訪才會更新。
+   */
+  private async recordPortIntel(
+    worldId: string,
+    portId: string,
+    guildId: string,
+    tick: number,
+  ): Promise<void> {
+    const portState = await this.prisma.portState.findUnique({
+      where: { worldId_portId: { worldId, portId } },
+      include: { market: true, influences: true },
+    });
+    if (!portState) return;
+    const share = Number(portState.influences.find((i) => i.guildId === guildId)?.share ?? 0);
+    const market = portState.market.map((m) => ({
+      commodityId: m.commodityId,
+      buyPrice: effectiveBuyPrice(m.price, share),
+      sellPrice: effectiveSellPrice(m.price, share),
+    }));
+    await this.prisma.portIntel.upsert({
+      where: { worldId_portId: { worldId, portId } },
+      create: { worldId, portId, lastVisitedTick: tick, market },
+      update: { lastVisitedTick: tick, market },
+    });
   }
 }

--- a/azure-voyage/apps/api/src/modules/world/world.service.spec.ts
+++ b/azure-voyage/apps/api/src/modules/world/world.service.spec.ts
@@ -177,6 +177,7 @@ describe("WorldService#getSnapshot self-heal for removed port ids", () => {
       },
       portInfluence: { findMany: jest.fn(async () => []) },
       discoveryRecord: { count: jest.fn(async () => 0) },
+      portIntel: { findMany: jest.fn(async () => []) },
       battle: { findMany: jest.fn(async () => battles) },
       $transaction: jest.fn(async (arg: unknown) => {
         if (typeof arg === "function") return arg(prisma);

--- a/azure-voyage/apps/api/src/modules/world/world.service.ts
+++ b/azure-voyage/apps/api/src/modules/world/world.service.ts
@@ -6,6 +6,8 @@ import {
   captainLevel,
   captainTitleForLevel,
   CONTENT_VERSION,
+  effectiveBuyPrice,
+  effectiveSellPrice,
   PORT_NOTABLE_TEMPLATES,
   PORTS,
   QUEST_CHAPTERS,
@@ -218,6 +220,24 @@ export class WorldService {
         },
       });
     }
+
+    // 7. 起始港情報（M32，市場情報不完全）：出生時人就站在家鄉港，第 0 天的市場
+    // 情報視為「即時已知」，否則新玩家一開局連自己家港的貿易建議都會被判定為
+    // 「從沒去過」。此時玩家商會尚未有任何影響力紀錄，share 固定為 0。
+    const homePortPlan = plan.ports.find((p) => p.portId === plan.homePortId)!;
+    await tx.portIntel.create({
+      data: {
+        worldId: world.id,
+        portId: plan.homePortId,
+        lastVisitedTick: 0,
+        market: homePortPlan.market.map((m) => ({
+          commodityId: m.commodityId,
+          buyPrice: effectiveBuyPrice(m.price, 0),
+          sellPrice: effectiveSellPrice(m.price, 0),
+        })),
+      },
+    });
+
     return world;
   }
 
@@ -232,7 +252,7 @@ export class WorldService {
   async getSnapshot(userId: string, worldId: string): Promise<WorldSnapshot> {
     const world = await this.getOwned(userId, worldId);
 
-    const [guilds, fleets, influenceRows, relicsFound] = await Promise.all([
+    const [guilds, fleets, influenceRows, relicsFound, visitedPortIds] = await Promise.all([
       this.prisma.guild.findMany({ where: { worldId } }),
       this.prisma.fleet.findMany({
         where: { worldId, guild: { kind: "PLAYER" } },
@@ -248,6 +268,7 @@ export class WorldService {
       this.prisma.discoveryRecord.count({
         where: { worldId, registered: true, discoveryId: { in: [...RELIC_DISCOVERY_IDS] } },
       }),
+      this.prisma.portIntel.findMany({ where: { worldId }, select: { portId: true } }),
     ]);
 
     // M21 縮編後既有存檔可能還有艦隊/待業航海士停在已刪除的港口 id；讀取時順便自我修復
@@ -296,6 +317,9 @@ export class WorldService {
     const dockedPortIds = new Set(
       fleets.map((f) => f.dockedPortId).filter((p): p is string => p !== null),
     );
+    // M32：visited 改為「真的去過（留下市場情報）」，不再只看「當下正停靠」
+    // （後者只是子集，見 docs 註記——舊版只反映停靠中港口，未追蹤歷史造訪）。
+    const everVisitedPortIds = new Set(visitedPortIds.map((v) => v.portId));
     const allShips = fleets.flatMap((f) => f.ships);
     const shipValue = allShips.reduce((acc, s) => acc + shipClassById(s.shipClassId).price, 0);
     // M31：破產倒數警示——資金 <=0 且全部艦隊只剩最後一艘船時才顯示，讓玩家
@@ -373,7 +397,7 @@ export class WorldService {
         regionId: p.regionId,
         coord: p.coord,
         size: p.size,
-        visited: dockedPortIds.has(p.id),
+        visited: everVisitedPortIds.has(p.id) || dockedPortIds.has(p.id),
       })),
       npcGuilds: guilds
         .filter((g) => g.kind === "NPC")

--- a/azure-voyage/apps/web/src/game/TradeRoutePanel.tsx
+++ b/azure-voyage/apps/web/src/game/TradeRoutePanel.tsx
@@ -55,6 +55,14 @@ export function TradeRoutePanel({ worldId, portId, onSetRoute }: Props) {
                 {commodityById(s.commodityId).name}：本港買 {s.buyPrice}，運至{" "}
                 <span className="text-foam">{s.sellPortName}</span> 賣 {s.sellPrice}
                 （單位獲利 <span className="text-gold">+{s.profitPerUnit}</span>・距離 {s.distance} 格）
+                <br />
+                <span className="text-xs text-slate-400">
+                  {s.sellIntelAgeTicks === undefined
+                    ? "情報：即時"
+                    : s.sellIntelAgeTicks <= 0
+                      ? "情報：即時（今日）"
+                      : `情報：${s.sellIntelAgeTicks} 天前，實際價格可能已變動`}
+                </span>
               </span>
               <button className="btn-ghost" disabled={busy} onClick={() => goTo(s.sellPortId)}>
                 前往

--- a/azure-voyage/docs/26-market-info-imperfection.md
+++ b/azure-voyage/docs/26-market-info-imperfection.md
@@ -1,0 +1,79 @@
+# 26 — M32：市場情報不完全（港口情報時效性）
+
+> 使用者要求的第三項里程碑「市場情報不完全」。排查後發現貿易路線建議
+> （`getTradeRouteSuggestions`，M24）其實是全知的——不論商會有沒有實際去過
+> 某港口，一律讀那個港口「當下」的即時市場真相。這代表玩家一開局就能看到
+> 全地圖 15 港的最佳套利路線，完全不需要真的出海打探，跟「不完全情報」的
+> 貿易遊戲精神背道而馳。
+
+## 1. 設計：起點港即時，其餘港口只認「上次抵達當下」的舊情報
+
+不去動 `getPortDetail`（玩家人正站在這個港口，看到即時市場天經地義），只改
+`getTradeRouteSuggestions`：
+
+- **起點港**（玩家目前停靠的港口）：照舊讀 `PortState` 即時真相。
+- **其餘候選港**：改讀新增的 `PortIntel` 表——商會對某港口「已知的市場情報」，
+  只在艦隊**實際抵達當下**寫入一次快照（`voyage.service.ts#advanceOneTick`
+  的 `arrivedPort` 分支），之後就是固定不變的舊資料，直到下次真的再訪。
+  **從沒去過的港口沒有 `PortIntel` 資料列，直接不列入候選**——不是「顯示
+  舊情報」，是「根本不知道」。
+
+停靠期間時間不會前進（docs/01 §核心循環），所以「抵達當下」snapshot 一次即
+代表這次停靠所知道的全部，不需要在停靠期間持續更新。
+
+```prisma
+model PortIntel {
+  id              String    @id @default(cuid())
+  worldId         String
+  world           GameWorld @relation(fields: [worldId], references: [id], onDelete: Cascade)
+  portId          String
+  lastVisitedTick Int
+  market          Json // [{commodityId, buyPrice, sellPrice}]（抵達當下算好的有效買賣價）
+
+  @@unique([worldId, portId])
+  @@index([worldId])
+}
+```
+
+`bestTradeRoutesFrom`（`packages/shared/src/rules/tradeRoutes.ts`）新增
+`PortMarketSnapshot#intelAgeTicks`／`TradeRouteSuggestion#sellIntelAgeTicks`：
+起點港 `undefined`＝即時，候選港的值＝`目前 tick - lastVisitedTick`，讓前端
+能標示情報時效。
+
+新世界的家鄉港在建檔當下（`world.service.ts#persistNewWorld`）就先種一筆
+`PortIntel`（`lastVisitedTick: 0`）——否則新玩家一開局連自己家港的貿易建議
+都會被判定成「從沒去過」。
+
+## 2. 順便修正的既有問題：`visited` 只反映「當下正停靠」
+
+`WorldSnapshot.knownPorts[].visited`（M1 起的欄位）原本只用
+`fleet.dockedPortId` 判斷「現在停在這裡」，離港之後這個港口的 `visited` 就
+變回 `false`，不是真正的「歷史造訪紀錄」。既然這次已經在追蹤
+「商會對某港口是否有情報」，`world.service.ts#getSnapshot` 順便改用
+`PortIntel` 是否存在來判定 `visited`（保留「目前正停靠」作為 OR 條件，
+防呆）。
+
+## 3. 測試
+
+- `packages/shared` `tradeRoutes.test.ts`：既有 4 個測試全數維持通過（新欄位
+  是可選的，不影響既有介面）。
+- `apps/api` `market.service.spec.ts`：改寫 `getTradeRouteSuggestions` 的
+  mock 為「起點港走 `portState.findUnique`、候選港走 `portIntel.findMany`」，
+  新增「從沒去過的港口不列入候選」測試。
+- `voyage.service.spec.ts`：mock 補上 `portState.findUnique` / `portIntel.upsert`
+  以涵蓋抵達時的情報凍結呼叫。
+- `world.service.spec.ts`：mock 補上 `portIntel.findMany`。
+- 真實環境端對端驗證（本機 Postgres + Redis + 真實 API/web server +
+  Playwright）：
+  1. 新世界建立後，家鄉港有且僅有 1 筆 `PortIntel`；此時查家鄉港的貿易路線
+     建議回傳空陣列（其餘 14 港都「從沒去過」）。
+  2. 設航線出港、真正跑過真實 tick pipeline 抵達一個新港：`PortIntel` 增加
+     為 2 筆；查詢新港的貿易路線建議，回傳「運回家鄉港賣」的建議，且
+     `sellIntelAgeTicks` 正確等於「目前 tick − 家鄉港上次造訪 tick」
+     （驗證中為 4）。
+  3. 前端 `TradeRoutePanel` 正確顯示「情報：N 天前，實際價格可能已變動」
+     字樣（截圖確認）。
+
+既有的 API 全部測試（21 個 suite、171 個測試）、`@azure-voyage/shared` 全部
+測試（23 個檔案、168 個測試）、API/web `tsc --noEmit`、`next build` 全數維持
+綠燈。

--- a/azure-voyage/packages/shared/src/rules/tradeRoutes.ts
+++ b/azure-voyage/packages/shared/src/rules/tradeRoutes.ts
@@ -11,6 +11,11 @@ export interface PortMarketSnapshot {
   coord: OffsetCoord;
   /** 該港各商品的目前有效買/賣價（已套用影響力折扣） */
   listings: { commodityId: string; buyPrice: number; sellPrice: number }[];
+  /**
+   * 情報時效性（M32，市場情報不完全）：undefined 代表即時真相（玩家目前所在的
+   * 起點港）；數字代表這是「上次實際抵達當下」凍結的舊情報，距今經過幾個 tick。
+   */
+  intelAgeTicks?: number;
 }
 
 export interface TradeRouteSuggestion {
@@ -24,6 +29,8 @@ export interface TradeRouteSuggestion {
   distance: number;
   /** 排序依據：單位獲利 / max(1, 距離)，距離越近、獲利越高分數越高 */
   score: number;
+  /** 賣出港情報的時效性；undefined＝即時（不會發生，賣出港恆為非起點港），見 PortMarketSnapshot#intelAgeTicks */
+  sellIntelAgeTicks?: number;
 }
 
 export function bestTradeRoutesFrom(
@@ -53,6 +60,7 @@ export function bestTradeRoutesFrom(
         profitPerUnit,
         distance,
         score: profitPerUnit / Math.max(1, distance),
+        sellIntelAgeTicks: target.intelAgeTicks,
       });
     }
   }


### PR DESCRIPTION
## Summary

- 使用者第三項要求的里程碑「市場情報不完全」。`getTradeRouteSuggestions`（M24）原本對全地圖 15 港讀即時真相，不論商會實際有沒有去過——玩家一開局就能看到全地圖最佳套利路線，跟「情報不完全」的貿易遊戲精神背道而馳。
- 新增 `PortIntel` 表：商會對某港口的「已知市場情報」，只在艦隊實際抵達當下凍結一次快照（停靠期間時間不前進，一次即可）。起點港（玩家目前所在）維持讀即時真相；其餘候選港只用 `PortIntel` 舊資料，從沒去過的港口直接排除在候選外。
- `TradeRouteSuggestion` 新增 `sellIntelAgeTicks`，前端 `TradeRoutePanel` 顯示「情報：N 天前，實際價格可能已變動」的時效性標示。
- 順便修正 `knownPorts.visited` 只反映「當下正停靠」而非真正歷史造訪的既有問題。

## Test plan

- [x] `@azure-voyage/shared` vitest：23 檔案、168 測試全數通過
- [x] `apps/api` jest：21 suite、171 測試全數通過（`market.service.spec.ts`／`voyage.service.spec.ts`／`world.service.spec.ts` 補上新 mock）
- [x] API/web `tsc --noEmit` 全綠
- [x] `next build` 成功
- [x] 真實環境端對端驗證（本機 Postgres + Redis + 真實 API/web server + Playwright）：新世界只有家鄉港有情報 → 貿易建議為空；真的出海抵達新港後，情報累積為 2 筆，貿易建議正確帶出 `sellIntelAgeTicks`；前端面板正確顯示情報時效文字（截圖確認）

詳見 `docs/26-market-info-imperfection.md`。

Claude-Session: https://claude.ai/code/session_013kDwmPmYtbENLcfMzDdnNF


---
_Generated by [Claude Code](https://claude.ai/code/session_013kDwmPmYtbENLcfMzDdnNF)_