### PR TITLE
Azure Voyage RPG P0~P2：引擎骨架 + 垂直切片內容 + 最小可玩前端

### DIFF
--- a/azure-voyage/apps/rpg/next-env.d.ts
+++ b/azure-voyage/apps/rpg/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/azure-voyage/apps/rpg/next.config.mjs
+++ b/azure-voyage/apps/rpg/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  transpilePackages: ["@azure-voyage/rpg-engine", "@azure-voyage/rpg-content"],
+};
+
+export default nextConfig;

--- a/azure-voyage/apps/rpg/package.json
+++ b/azure-voyage/apps/rpg/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@azure-voyage/rpg",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev --port 3100",
+    "build": "next build",
+    "start": "next start --port 3100",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "echo \"rpg: no unit tests in P1/P2, covered by rpg-engine/rpg-content\""
+  },
+  "dependencies": {
+    "@azure-voyage/rpg-content": "workspace:*",
+    "@azure-voyage/rpg-engine": "workspace:*",
+    "next": "^15.1.4",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@azure-voyage/tsconfig": "workspace:*",
+    "@types/node": "^22.10.5",
+    "@types/react": "^19.0.2",
+    "@types/react-dom": "^19.0.2",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.49",
+    "tailwindcss": "^3.4.17",
+    "typescript": "^5.7.2"
+  }
+}

--- a/azure-voyage/apps/rpg/postcss.config.mjs
+++ b/azure-voyage/apps/rpg/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/azure-voyage/apps/rpg/src/app/globals.css
+++ b/azure-voyage/apps/rpg/src/app/globals.css
@@ -1,0 +1,20 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  background-color: #0b1526;
+  color: #e6eef7;
+}
+
+.panel {
+  @apply rounded-lg border border-foam/20 bg-wave/60 p-4;
+}
+
+.btn {
+  @apply rounded-md bg-gold px-4 py-2 text-sm font-semibold text-abyss transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-40;
+}
+
+.btn-ghost {
+  @apply rounded-md border border-foam/30 px-4 py-2 text-sm text-foam transition hover:bg-foam/10 disabled:cursor-not-allowed disabled:opacity-40;
+}

--- a/azure-voyage/apps/rpg/src/app/layout.tsx
+++ b/azure-voyage/apps/rpg/src/app/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "蒼瀾航路：晨汐紀事",
+  description: "Azure Voyage RPG — 敘事探索原型（P1/P2 垂直切片）",
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="zh-Hant">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/azure-voyage/apps/rpg/src/app/page.tsx
+++ b/azure-voyage/apps/rpg/src/app/page.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+// GameClient 讀寫 localStorage 存檔，開局狀態依裝置而異——用 ssr:false 避免
+// 伺服器端渲染出的初始 HTML 跟客戶端 hydrate 後的存檔內容對不上。
+const GameClient = dynamic(() => import("@/game/GameClient").then((m) => m.GameClient), { ssr: false });
+
+export default function Page() {
+  return <GameClient />;
+}

--- a/azure-voyage/apps/rpg/src/game/GameClient.tsx
+++ b/azure-voyage/apps/rpg/src/game/GameClient.tsx
@@ -1,0 +1,284 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  RpgEngine,
+  evaluateCondition,
+  type CaptainStat,
+  type GamePhase,
+  type PlayNode,
+  type Season,
+} from "@azure-voyage/rpg-engine";
+import { AZURE_VOYAGE_RPG_CONTENT as content, createStartState } from "@azure-voyage/rpg-content";
+import { clearSave, loadSave, persistSave } from "@/lib/save";
+
+const STAT_LABELS: Record<CaptainStat, string> = {
+  lead: "統率",
+  nav: "航海",
+  combat: "戰鬥",
+  trade: "交易",
+  lore: "見聞",
+};
+
+const PHASE_LABELS: Record<GamePhase, string> = {
+  DAWN: "黎明",
+  DAY: "白晝",
+  DUSK: "黃昏",
+  NIGHT: "夜晚",
+};
+
+const SEASON_LABELS: Record<Season, string> = {
+  SPRING: "春",
+  SUMMER: "夏",
+  AUTUMN: "秋",
+  WINTER: "冬",
+};
+
+function makeEngine(): RpgEngine {
+  const saved = loadSave();
+  return new RpgEngine(content, saved ?? createStartState());
+}
+
+export function GameClient() {
+  const [engine, setEngine] = useState<RpgEngine>(() => makeEngine());
+  const [activeNode, setActiveNode] = useState<PlayNode | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [showJournal, setShowJournal] = useState(false);
+
+  // 每次互動後用一個新的 SaveState 參照觸發重繪，同時寫入 localStorage。
+  const [, setVersion] = useState(0);
+  function sync() {
+    persistSave(engine.state);
+    setVersion((v) => v + 1);
+  }
+
+  function settle(node: PlayNode) {
+    setActiveNode(node.kind === "end" ? null : node);
+    sync();
+  }
+
+  function handleInteract(hotspotId: string) {
+    setNotice(null);
+    const node = engine.interact(hotspotId);
+    if (!node) {
+      setNotice("這裡暫時沒有新的事情發生。");
+      return;
+    }
+    settle(node);
+  }
+
+  function handleContinue() {
+    settle(engine.continue());
+  }
+
+  function handleChoose(index: number) {
+    settle(engine.choose(index));
+  }
+
+  function handleWait() {
+    setNotice(null);
+    engine.advanceTime(1);
+    sync();
+  }
+
+  function handleTravel(sceneId: string) {
+    setNotice(null);
+    try {
+      engine.travelTo(sceneId);
+      sync();
+    } catch (err) {
+      setNotice(err instanceof Error ? err.message : "現在還不能去那裡。");
+    }
+  }
+
+  /** 世界地圖層：切換到另一個已解鎖的港口，預設進入該港口的第一個場景。 */
+  function handleEnterArea(areaId: string) {
+    setNotice(null);
+    const target = content.areas[areaId];
+    const entryScene = target.scenes[0];
+    try {
+      engine.travelTo(entryScene);
+      sync();
+    } catch (err) {
+      setNotice(err instanceof Error ? err.message : "現在還不能去那裡。");
+    }
+  }
+
+  function handleNewGame() {
+    if (!window.confirm("要放棄目前的存檔，重新開始一輪新旅程嗎？")) return;
+    clearSave();
+    const fresh = new RpgEngine(content, createStartState());
+    setEngine(fresh);
+    setActiveNode(null);
+    setNotice(null);
+    persistSave(fresh.state);
+    setVersion((v) => v + 1);
+  }
+
+  const state = engine.state;
+  const scene = content.scenes[state.currentSceneId];
+  const sceneView = engine.getSceneView(state.currentSceneId);
+  const area = content.areas[scene.areaId];
+  const areaView = engine.getAreaView(area.id);
+  const sceneOpen = engine.isSceneOpen(scene);
+
+  const questSummaries = useMemo(
+    () =>
+      Object.values(content.quests)
+        .filter((q) => evaluateCondition(q.precondition, state))
+        .map((q) => ({
+          quest: q,
+          objectives: q.objectives.map((o) => ({
+            objective: o,
+            done: evaluateCondition(o.completeWhen, state),
+          })),
+        })),
+    [state],
+  );
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-4 p-6">
+      <header className="panel flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-lg font-semibold text-gold">蒼瀾航路：晨汐紀事</h1>
+          <p className="text-sm text-foam/80">
+            第 {state.clock.day} 日・{PHASE_LABELS[state.clock.phase]}・{SEASON_LABELS[state.clock.season]}季
+          </p>
+        </div>
+        <div className="flex gap-3 text-xs text-foam/80">
+          {Object.entries(STAT_LABELS).map(([stat, label]) => (
+            <span key={stat}>
+              {label} {state.captainStats[stat as CaptainStat]}
+            </span>
+          ))}
+        </div>
+        <div className="flex gap-2">
+          <button className="btn-ghost" onClick={() => setShowJournal((v) => !v)}>
+            {showJournal ? "關閉日誌" : "航海日誌"}
+          </button>
+          <button className="btn-ghost" onClick={handleNewGame}>
+            重新開始
+          </button>
+        </div>
+      </header>
+
+      {showJournal && (
+        <section className="panel space-y-3">
+          <h2 className="font-semibold text-foam">航海日誌</h2>
+          {questSummaries.length === 0 && <p className="text-sm text-foam/60">目前沒有進行中的任務。</p>}
+          {questSummaries.map(({ quest, objectives }) => (
+            <div key={quest.id} className="space-y-1 border-t border-foam/10 pt-2 first:border-none first:pt-0">
+              <p className="text-sm font-medium text-gold">
+                [{quest.kind === "MAIN" ? "主線" : quest.kind === "SIDE" ? "支線" : quest.kind}] {quest.title}
+              </p>
+              {objectives.map(({ objective, done }) => (
+                <p key={objective.id} className={`text-xs ${done ? "text-foam/50 line-through" : "text-foam/90"}`}>
+                  {done ? "✓" : "□"} {objective.description}
+                </p>
+              ))}
+            </div>
+          ))}
+        </section>
+      )}
+
+      {state.unlocked.areas.length > 1 && (
+        <nav className="panel flex flex-wrap gap-2">
+          <span className="text-xs text-foam/60">世界地圖・{content.regions[area.regionId].name}：</span>
+          {state.unlocked.areas.map((areaId) => {
+            const a = content.areas[areaId];
+            return (
+              <button
+                key={a.id}
+                className={a.id === area.id ? "btn" : "btn-ghost"}
+                disabled={a.id === area.id}
+                onClick={() => handleEnterArea(a.id)}
+              >
+                {a.name}
+              </button>
+            );
+          })}
+        </nav>
+      )}
+
+      <nav className="panel flex flex-wrap gap-2">
+        <span className="text-xs text-foam/60">{area.name}：</span>
+        {areaView.scenes.map(({ scene: s, open }) => (
+          <button
+            key={s.id}
+            className={s.id === scene.id ? "btn" : "btn-ghost"}
+            disabled={!open || s.id === scene.id}
+            onClick={() => handleTravel(s.id)}
+            title={open ? undefined : "現在沒有開放"}
+          >
+            {s.name}
+            {!open && "（休息中）"}
+          </button>
+        ))}
+      </nav>
+
+      <section className="panel space-y-3">
+        <h2 className="text-base font-semibold text-foam">{scene.name}</h2>
+        {!sceneOpen && (
+          <p className="text-sm text-foam/60">
+            現在不是這裡開放的時段，先在附近等等吧。
+            <button className="btn-ghost ml-2" onClick={handleWait}>
+              等待一段時間
+            </button>
+          </p>
+        )}
+        {sceneOpen && (
+          <div className="flex flex-wrap gap-2">
+            {sceneView.hotspots.map((h) => (
+              <button key={h.id} className="btn-ghost" onClick={() => handleInteract(h.id)} disabled={!!activeNode}>
+                {h.label}
+              </button>
+            ))}
+            <button className="btn-ghost" onClick={handleWait} disabled={!!activeNode}>
+              等待一段時間
+            </button>
+          </div>
+        )}
+        {notice && <p className="text-sm text-foam/60">{notice}</p>}
+      </section>
+
+      {activeNode && (
+        <section className="panel space-y-3 border-gold/40">
+          {activeNode.kind === "dialogue" && (
+            <div className="space-y-3">
+              <p className="text-sm font-semibold text-gold">{activeNode.speaker}</p>
+              <p className="whitespace-pre-wrap text-sm leading-relaxed text-foam/90">{activeNode.text}</p>
+              <button className="btn" onClick={handleContinue}>
+                繼續
+              </button>
+            </div>
+          )}
+          {activeNode.kind === "checkResult" && (
+            <div className="space-y-3">
+              <p className="text-sm text-foam/80">
+                {STAT_LABELS[activeNode.stat]}判定（門檻 {activeNode.difficulty}，你的實力 {activeNode.playerValue}）
+              </p>
+              <p className={`text-base font-semibold ${activeNode.success ? "text-gold" : "text-foam/70"}`}>
+                {activeNode.success ? "順利過關" : "沒能如意，但故事還是往下走"}
+              </p>
+              <button className="btn" onClick={handleContinue}>
+                繼續
+              </button>
+            </div>
+          )}
+          {activeNode.kind === "choice" && (
+            <div className="space-y-3">
+              <p className="text-sm text-foam/90">{activeNode.prompt}</p>
+              <div className="flex flex-col gap-2">
+                {activeNode.options.map((opt) => (
+                  <button key={opt.index} className="btn-ghost text-left" onClick={() => handleChoose(opt.index)}>
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+        </section>
+      )}
+    </div>
+  );
+}

--- a/azure-voyage/apps/rpg/src/lib/save.ts
+++ b/azure-voyage/apps/rpg/src/lib/save.ts
@@ -1,0 +1,25 @@
+import type { SaveState } from "@azure-voyage/rpg-engine";
+
+const SAVE_KEY = "azure-voyage-rpg.save.v1";
+
+/** SaveState 全部由陣列/物件/純值構成（見 rpg-engine/types.ts），可直接 JSON 化。 */
+export function loadSave(): SaveState | null {
+  if (typeof window === "undefined") return null;
+  const raw = window.localStorage.getItem(SAVE_KEY);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as SaveState;
+  } catch {
+    return null;
+  }
+}
+
+export function persistSave(state: SaveState): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(SAVE_KEY, JSON.stringify(state));
+}
+
+export function clearSave(): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.removeItem(SAVE_KEY);
+}

--- a/azure-voyage/apps/rpg/tailwind.config.ts
+++ b/azure-voyage/apps/rpg/tailwind.config.ts
@@ -1,0 +1,17 @@
+import type { Config } from "tailwindcss";
+
+export default {
+  content: ["./src/**/*.{ts,tsx}"],
+  theme: {
+    extend: {
+      colors: {
+        // 沿用沙盒版（apps/web）的蒼瀾主題色，兩款遊戲共享同一個世界的視覺語言。
+        abyss: "#0b1526",
+        wave: "#12283f",
+        foam: "#9fc3e0",
+        gold: "#d9a441",
+      },
+    },
+  },
+  plugins: [],
+} satisfies Config;

--- a/azure-voyage/apps/rpg/tsconfig.json
+++ b/azure-voyage/apps/rpg/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "ES2022"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/azure-voyage/docs/30-rpg-p0-p2.md
+++ b/azure-voyage/docs/30-rpg-p0-p2.md
@@ -1,0 +1,115 @@
+# 30 — Azure Voyage RPG：P0 引擎骨架 + P1 垂直切片 + P2 主線第一部
+
+> 實作 `docs/29` 路線圖的前三個階段。不是設計提案——這是真正可玩、可測試
+> 的程式碼：新增 `packages/rpg-engine`（純框架）、`packages/rpg-content`
+> （蒼瀾世界的內容包）、`apps/rpg`（最小可玩前端）。不改動既有沙盒經營版
+> （`apps/web`/`apps/api`），兩款遊戲並存，共用同一個世界觀。
+
+## 1. P0：`packages/rpg-engine`（純框架，無內容）
+
+依 `docs/29` §2–§13 落地：
+
+- `types.ts`：`Condition`/`Effect` 統一語言、三層世界架構
+  （`WorldRegion`/`Area`/`Scene`/`Hotspot`）、事件節點型別（`Dialogue`/
+  `Choice`/`SkillCheck`/`Effect`/`Goto`）、`WorldState`、`SaveState`。
+- `condition.ts` / `effect.ts`：條件求值與後果套用。**踩到一個真實 bug**：
+  `WorldState` 的 `guildOrder`/`regionCorruption` 是 `Record<string,
+  number>`，鍵本身就含有點（例如 `"npc.crimson_sails"`）；原本用
+  `path.split(".")` 遞迴逐層取值，會把這種鍵誤拆成好幾段。改成「只在第一個
+  點切一刀」的兩層 `splitPath`（欄位名 + 選填的 record 鍵），鍵裡的點不再
+  被誤判為巢狀路徑。
+- `engine.ts`：`RpgEngine` 類別——`interact`/`continue`/`choose` 三個入口
+  推進事件節點，`getSceneView`/`getAreaView`/`getWorldMapView` 供 UI 讀取，
+  `travelTo`/`isSceneOpen` 處理場景時段閘門，`advanceTime` 供玩家主動等待。
+  **另一個真實 bug**：事件池加權隨機選取時，`weight: 0`（設計上「只能被
+  `startEvent()` 直接觸發，不進隨機池」的稀有事件）在候選只剩它自己時，
+  因為 `totalWeight === 0` 導致演算法必然選中它。修成候選階段直接濾掉
+  `weight <= 0` 的事件。
+- `validate.ts`：建置期內容檢查——所有 id 引用完整、事件節點無孤島。
+
+**22 個單元測試**（`condition.test.ts`/`effect.test.ts`/`engine.test.ts`），
+含上述兩個 bug 的回歸測試、時段閘門、完整事件播放（dialogue→choice→
+effect→dialogue→end）、once/cooldown/weight 過濾、技能判定的確定性驗證
+（注入 `rng`）。
+
+## 2. P1+P2：`packages/rpg-content`（垂直切片內容）
+
+對映小說（`docs/28`）第一部第一～四章、第六章，全部原創文字，重寫成事件
+宣告：
+
+- **奧雷利亞 3 場景**：港務廳（`DAWN/DAY/DUSK` 開）、錨與星酒館
+  （`DUSK/NIGHT` 開）、中央市場（`DAWN/DAY` 開）——示範 `docs/29` 設計的
+  「白天皇宮、夜晚黑市」時段閘門模式。
+- **佩爾蘭 1 場景**：碼頭（老漁夫圖克），解鎖條件是 `flag.crew_assembled`
+  （呼應小說第四章的敘事順序——組好班底、站穩腳跟後才順道繞去補鹽）。
+- **9 個事件**：開場（掛名入行）、公告欄傳聞（repeatable flavor）、招募
+  布拉姆／賽菈（各一個 `lead`/`trade` 技能判定，失敗不是拒絕、只是換一種
+  說服過程——`docs/29` 強調的「判定即敘事」）、酒館流言（repeatable
+  flavor）、第一筆交易（`trade` 判定）、緋帆團初現（`combat`/`nav`
+  二選一判定，兩條路都推進劇情，勝負只影響過場文字，統一觸發
+  `crimsonThreat +10` 並解鎖佩爾蘭）、佩爾蘭支線兩段（答應/拒絕分支，
+  拒絕會讓後續事件永久不可達——玩家的選擇是真的有後果）。
+- **4 個任務宣告**（`quests.ts`）：主線 ch1–ch3 對應現有沙盒版 M28 的前三章
+  目標語意，支線「老漁夫的家傳鹽田」。目標判定沿用 M28 QuestService「用
+  既有可查詢狀態」的哲學，全部讀事件留下的 flag，任務獎勵已經在完成任務的
+  事件 effect 節點直接發放，`quests.ts` 的 `rewards` 欄位純粹是任務面板的
+  文案來源，引擎不會自動套用它，避免重複發放。
+- `createStartState()`：新遊戲存檔工廠——起始港口（奧雷利亞）的全部場景
+  一開始就看得到（沒有港內迷霧），佩爾蘭則要等事件解鎖。
+
+**4 個測試**：內容包無孤島引用、任務目標條件語法正確、**完整主線＋支線
+一輪遊玩**（開場→招募雙人→第一筆交易→緋帆團初現→解鎖佩爾蘭→答應/拒絕
+兩種支線分支），確定性 rng 注入驗證每一步的 flag/affinity/worldState/
+unlocked 變化。
+
+## 3. P1：`apps/rpg`（最小可玩前端）
+
+獨立 Next.js app（`transpilePackages` 指向兩個新 package，不需要後端，
+純前端 + `localStorage` 存檔——`docs/29` §13.2 存檔模型本身就是純資料
+（陣列/物件/純值），可以直接 `JSON.stringify`）。
+
+- `GameClient.tsx`：單頁遊戲殼——世界地圖層（已解鎖港口，超過 1 個才顯示）
+  → 港口場景切換（依 `isSceneOpen` 灰階不可點）→ 熱點互動 → 事件面板
+  （dialogue/choice/checkResult 三種節點的渲染）→ 航海日誌（任務清單，
+  即時用 `evaluateCondition` 算完成狀態，不需要額外的「任務進度」欄位）。
+- `page.tsx` 用 `next/dynamic` + `ssr: false` 掛載 `GameClient`——存檔內容
+  依裝置而異，避免伺服器渲染的初始 HTML 跟客戶端 hydrate 後的內容對不上。
+- `save.ts`：`localStorage` 讀寫，`SaveState` 全由純資料構成，不需要自訂
+  序列化。
+
+## 4. 端對端驗證
+
+本機啟動 `apps/rpg`（`next dev -p 3100`，純前端、不需要 Postgres/Redis），
+Playwright 完整跑一輪：
+
+1. 開場港務廳（選擇回應台詞）→ 確認 `flag.game_started`、時鐘推進。
+2. 等到黃昏、進入酒館，依序招募布拉姆／賽菈（技能判定隨機成功/勉強成功
+   兩種過場都有覆蓋）→ 確認航海日誌「組建班底」打勾。
+3. 等到隔天白晝、進入市場，完成第一筆交易 → 市場自己的 `advanceTime`
+   效果把場景推進到休息時段，驗證「完成事件當下把自己所在的場景關門」
+   這個邊界情況會正確反映在 UI（熱點消失、顯示「休息中」）。
+4. 緋帆團初現事件（碼頭瞭望，正面周旋分支）→ 確認 `crimsonThreat` 累加、
+   世界地圖層新增佩爾蘭、`getWorldMapView` 能切換港口。
+5. 佩爾蘭老漁夫圖克：答應幫忙 → 再訪完成支線，確認道具 `item.perlan_salt`
+   進背包、`area.perlan` 聲望 +10。
+6. 航海日誌四項任務（主線三章 + 支線）全數打勾，畫面截圖確認。
+
+過程中修正一個真實的前端設計缺口：**最初完全沒有「切換港口」的 UI**——
+只做了同一港口內的場景切換，佩爾蘭解鎖後玩家其實無路可去。補上世界地圖層
+（列出 `state.unlocked.areas`，點擊進入該港口的第一個場景）後才打通。
+
+## 5. 測試/建置總結
+
+- `@azure-voyage/rpg-engine`：22 測試全綠。
+- `@azure-voyage/rpg-content`：4 測試全綠。
+- `@azure-voyage/rpg`：`tsc --noEmit`、`next build` 全綠。
+- 新增三個套件的 ESLint 全綠（`eslint.config.mjs` 補上
+  `apps/rpg/next-env.d.ts` 忽略規則，比照 `apps/web` 既有寫法）。
+- 既有 `@azure-voyage/api`／`@azure-voyage/web` 的 `tsc --noEmit` 確認不受
+  影響（本次改動完全沒有碰沙盒經營版的程式碼）。
+
+## 6. 下一步（P3–P5，見 docs/29 §14）
+
+P3 開放鐵崖／絹風／子午海域與更多支線，P4 接上柯爾/賽菈斐娜/奧丁三條真結局
+支線與四種結局分支文字（可直接引用 `docs/28` 小說正文），P5 打磨立繪/音效/
+存檔雲端化。

--- a/azure-voyage/eslint.config.mjs
+++ b/azure-voyage/eslint.config.mjs
@@ -12,6 +12,7 @@ export default tseslint.config(
       "**/coverage/**",
       "**/*.config.{js,mjs,ts}",
       "apps/web/next-env.d.ts",
+      "apps/rpg/next-env.d.ts",
     ],
   },
   js.configs.recommended,

--- a/azure-voyage/packages/rpg-content/package.json
+++ b/azure-voyage/packages/rpg-content/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@azure-voyage/rpg-content",
+  "version": "0.1.0",
+  "private": true,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -p tsconfig.json --watch --preserveWatchOutput",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@azure-voyage/rpg-engine": "workspace:*"
+  },
+  "devDependencies": {
+    "@azure-voyage/tsconfig": "workspace:*",
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.8"
+  }
+}

--- a/azure-voyage/packages/rpg-content/src/content.test.ts
+++ b/azure-voyage/packages/rpg-content/src/content.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import { RpgEngine, evaluateCondition, validateContent } from "@azure-voyage/rpg-engine";
+import { AZURE_VOYAGE_RPG_CONTENT as content, createStartState } from "./content";
+
+function newEngine(rng: () => number = () => 1) {
+  return new RpgEngine(content, createStartState(), rng);
+}
+
+/** 一路 continue 直到需要玩家輸入（choice）或事件結束。 */
+function drain(engine: RpgEngine) {
+  let node = engine.continue();
+  while (node.kind === "dialogue" || node.kind === "checkResult") node = engine.continue();
+  return node;
+}
+
+describe("AZURE_VOYAGE_RPG_CONTENT", () => {
+  it("has no dangling references", () => {
+    expect(validateContent(content)).toEqual([]);
+  });
+
+  it("every quest objective condition is well-formed against a fresh state", () => {
+    const state = createStartState();
+    for (const quest of Object.values(content.quests)) {
+      for (const objective of quest.objectives) {
+        expect(() => evaluateCondition(objective.completeWhen, state)).not.toThrow();
+      }
+    }
+  });
+});
+
+describe("main quest chain playthrough (favorable rng)", () => {
+  it("plays opening -> recruit crew -> first trade -> first battle -> unlocks Perlan -> side quest", () => {
+    const engine = newEngine(() => 1); // 高擾動，讓五維判定盡量成功
+
+    // ── 開場：港務廳長桌（白天開）──
+    let node = engine.interact("hotspot.harbor_office.desk");
+    expect(node?.kind).toBe("dialogue");
+    node = drain(engine);
+    expect(node.kind).toBe("choice");
+    node = engine.choose(0);
+    node = drain(engine);
+    expect(node.kind).toBe("end");
+    expect(engine.state.flags).toContain("flag.game_started");
+    expect(engine.state.clock.phase).toBe("DAY"); // opening 事件推進了 1 個時段
+
+    // ── 等到傍晚，酒館開門，招募布拉姆與賽菈 ──
+    engine.advanceTime(1); // DAY -> DUSK
+    engine.travelTo("scene.aurelia.tavern");
+
+    node = engine.interact("hotspot.tavern.bar"); // 只有 recruit_bram 符合前置條件
+    expect(node?.kind).toBe("dialogue");
+    node = drain(engine);
+    expect(node.kind).toBe("end");
+    expect(engine.state.flags).toContain("flag.recruited_bram");
+
+    node = engine.interact("hotspot.tavern.bar"); // 現在輪到 recruit_sera
+    expect(node?.kind).toBe("dialogue");
+    node = drain(engine);
+    expect(node.kind).toBe("end");
+    expect(engine.state.flags).toContain("flag.crew_assembled");
+
+    // ── 等到隔天白天，市場開門，完成第一筆交易 ──
+    engine.advanceTime(3); // DUSK -> NIGHT -> DAWN(+1day) -> DAY
+    expect(engine.state.clock.phase).toBe("DAY");
+    engine.travelTo("scene.aurelia.market");
+
+    node = engine.interact("hotspot.market.stalls");
+    expect(node?.kind).toBe("dialogue");
+    node = drain(engine);
+    expect(node.kind).toBe("end");
+    expect(engine.state.flags).toContain("flag.first_trade_done");
+
+    // ── 緋帆團初現：碼頭瞭望（crew_assembled 後才會出現的熱點）──
+    node = engine.interact("hotspot.market.lookout");
+    expect(node?.kind).toBe("dialogue");
+    node = drain(engine);
+    expect(node.kind).toBe("choice");
+    node = engine.choose(0); // 迎上去正面周旋
+    expect(node.kind).toBe("checkResult");
+    node = drain(engine);
+    expect(node.kind).toBe("end");
+    expect(engine.state.flags).toContain("flag.first_battle_done");
+    expect(engine.state.worldState.crimsonThreat).toBe(10);
+    expect(engine.state.unlocked.areas).toContain("area.perlan");
+    expect(engine.state.unlocked.scenes).toContain("scene.perlan.docks");
+
+    // ── 佩爾蘭支線：老漁夫圖克 ──
+    engine.travelTo("scene.perlan.docks");
+    node = engine.interact("hotspot.perlan.old_fisherman"); // 只有 meet_tuk 符合條件
+    expect(node?.kind).toBe("dialogue");
+    node = drain(engine);
+    expect(node.kind).toBe("choice");
+    node = engine.choose(0); // 答應幫忙重開鹽田
+    node = drain(engine);
+    expect(node.kind).toBe("end");
+    expect(engine.state.flags).toContain("flag.perlan_help_promised");
+    expect(engine.state.affinity["npc.tuk"]).toBe(20);
+
+    node = engine.interact("hotspot.perlan.old_fisherman"); // 現在輪到 saltfield_reopened
+    expect(node?.kind).toBe("dialogue");
+    node = drain(engine);
+    expect(node.kind).toBe("end");
+    expect(engine.state.flags).toContain("flag.perlan_quest_completed");
+    expect(engine.state.inventory).toContain("item.perlan_salt");
+    expect(engine.state.reputation["area.perlan"]).toBe(10);
+
+    // ── 主線任務目標此刻應全數判定為完成 ──
+    for (const questId of ["quest.ch1_first_trade", "quest.ch2_crew", "quest.ch3_first_battle", "quest.side_perlan"]) {
+      const quest = content.quests[questId];
+      for (const objective of quest.objectives) {
+        expect(evaluateCondition(objective.completeWhen, engine.state)).toBe(true);
+      }
+    }
+  });
+
+  it("declining the Perlan quest leaves the saltfield event permanently unreachable", () => {
+    const engine = newEngine(() => 1);
+    // 快轉到緋帆團事件解鎖佩爾蘭：直接操作旗標以跳過前置流程，只驗證拒絕分支。
+    engine.interact("hotspot.harbor_office.desk");
+    drain(engine);
+    engine.choose(0);
+    drain(engine);
+    engine.advanceTime(1);
+    engine.travelTo("scene.aurelia.tavern");
+    engine.interact("hotspot.tavern.bar"); // recruit_bram
+    drain(engine);
+    engine.interact("hotspot.tavern.bar"); // recruit_sera
+    drain(engine);
+    engine.advanceTime(3);
+    engine.travelTo("scene.aurelia.market");
+    engine.interact("hotspot.market.stalls");
+    drain(engine);
+    engine.interact("hotspot.market.lookout");
+    drain(engine);
+    engine.choose(0);
+    drain(engine);
+
+    engine.travelTo("scene.perlan.docks");
+    engine.interact("hotspot.perlan.old_fisherman");
+    drain(engine);
+    engine.choose(1); // 拒絕幫忙
+    drain(engine);
+    expect(engine.state.flags).toContain("flag.perlan_declined");
+
+    const second = engine.interact("hotspot.perlan.old_fisherman");
+    expect(second).toBeNull(); // meet_tuk 已完成（once），saltfield_reopened 前置條件不成立
+  });
+});

--- a/azure-voyage/packages/rpg-content/src/content.ts
+++ b/azure-voyage/packages/rpg-content/src/content.ts
@@ -1,0 +1,41 @@
+import { createInitialSaveState, type ContentPack, type SaveState } from "@azure-voyage/rpg-engine";
+import { REGIONS, AREAS } from "./regionsAreas";
+import { AURELIA_SCENES } from "./scenes/aurelia";
+import { PERLAN_SCENES } from "./scenes/perlan";
+import { OPENING_EVENTS } from "./events/opening";
+import { TAVERN_EVENTS } from "./events/tavern";
+import { MARKET_EVENTS } from "./events/market";
+import { PERLAN_EVENTS } from "./events/perlan";
+import { NPCS } from "./npcs";
+import { QUESTS } from "./quests";
+
+/**
+ * P1/P2 垂直切片內容包（docs/29 §14 路線圖）：奧雷利亞 3 場景 + 佩爾蘭支線。
+ * 對映小說（docs/28）第一部第一～四章、第六章。
+ */
+export const AZURE_VOYAGE_RPG_CONTENT: ContentPack = {
+  regions: REGIONS,
+  areas: AREAS,
+  scenes: { ...AURELIA_SCENES, ...PERLAN_SCENES },
+  events: { ...OPENING_EVENTS, ...TAVERN_EVENTS, ...MARKET_EVENTS, ...PERLAN_EVENTS },
+  npcs: NPCS,
+  quests: QUESTS,
+  startSceneId: "scene.aurelia.harbor_office",
+};
+
+/**
+ * 新遊戲存檔：抵達一個已解鎖的港口，該港口全部場景一開始就看得到（沒有
+ * 港內迷霧），玩家可以自由在港務廳／酒館／市場之間走動——只是各場景是否
+ * 「開門」還要看 timeGate（見 scenes/aurelia.ts）。
+ */
+export function createStartState(): SaveState {
+  const base = createInitialSaveState({
+    startSceneId: AZURE_VOYAGE_RPG_CONTENT.startSceneId,
+    startAreaId: "area.aurelia",
+    startRegionId: "region.amber_gulf",
+  });
+  return {
+    ...base,
+    unlocked: { ...base.unlocked, scenes: [...AREAS["area.aurelia"].scenes] },
+  };
+}

--- a/azure-voyage/packages/rpg-content/src/events/market.ts
+++ b/azure-voyage/packages/rpg-content/src/events/market.ts
@@ -1,0 +1,144 @@
+import type { GameEvent } from "@azure-voyage/rpg-engine";
+
+/** 中央市場：第一筆交易（docs/28 第二章改編）與緋帆團初現（第六章改編）。 */
+export const MARKET_EVENTS: Record<string, GameEvent> = {
+  "event.market.first_trade": {
+    id: "event.market.first_trade",
+    precondition: { kind: "flag", flag: "flag.game_started", value: true },
+    weight: 100,
+    once: true,
+    entryNodeId: "n1",
+    nodes: [
+      {
+        kind: "dialogue",
+        id: "n1",
+        speaker: "市場掮客",
+        text: "「新來的？」他打量著你，又打量著你那艘船況不佳的縱帆船，「要進貨還是出貨？」",
+        goto: "check_trade",
+      },
+      {
+        kind: "skillCheck",
+        id: "check_trade",
+        stat: "trade",
+        difficulty: 15,
+        onSuccess: "n_win",
+        onFailure: "n_ok",
+      },
+      {
+        kind: "dialogue",
+        id: "n_win",
+        speaker: "旁白",
+        text: "你精準地看穿了對方的報價空間，用低於市價的成本，換到了一船划算的橄欖油。",
+        goto: "n_close",
+      },
+      {
+        kind: "dialogue",
+        id: "n_ok",
+        speaker: "旁白",
+        text: "你花了比預期多一點的價錢，但貨到底是進了船艙。帳本上第一筆墨跡，還是落下了。",
+        goto: "n_close",
+      },
+      {
+        kind: "effect",
+        id: "n_close",
+        effect: { setFlags: ["flag.first_trade_done"], advanceTime: 1 },
+        goto: "n_end",
+      },
+      {
+        kind: "dialogue",
+        id: "n_end",
+        speaker: "旁白",
+        text: "碼頭的掮客多看了你的船兩眼，壓低聲音議論——「新來的。撐得過這季風暴嗎？」",
+        goto: "END",
+      },
+    ],
+  },
+  "event.market.crimson_scout": {
+    id: "event.market.crimson_scout",
+    precondition: {
+      kind: "and",
+      all: [
+        { kind: "flag", flag: "flag.crew_assembled", value: true },
+        { kind: "not", cond: { kind: "flag", flag: "flag.first_battle_done", value: true } },
+      ],
+    },
+    weight: 100,
+    once: true,
+    entryNodeId: "n1",
+    nodes: [
+      {
+        kind: "dialogue",
+        id: "n1",
+        speaker: "旁白",
+        text: "碼頭瞭望台傳來示警的鐘聲——一艘掛著緋紅船帆的武裝快船，正朝著晨汐商會的方向撲來。",
+        goto: "n2",
+      },
+      {
+        kind: "choice",
+        id: "n2",
+        prompt: "布拉姆看著你，等你下令。",
+        options: [
+          { label: "迎上去，正面周旋", goto: "check_combat" },
+          { label: "把船逼進淺水暗礁區，甩開他們", goto: "check_nav" },
+        ],
+      },
+      {
+        kind: "skillCheck",
+        id: "check_combat",
+        stat: "combat",
+        difficulty: 25,
+        onSuccess: "n_win",
+        onFailure: "n_scar",
+      },
+      {
+        kind: "skillCheck",
+        id: "check_nav",
+        stat: "nav",
+        difficulty: 20,
+        onSuccess: "n_win",
+        onFailure: "n_scar",
+      },
+      {
+        kind: "dialogue",
+        id: "n_win",
+        speaker: "旁白",
+        text: "砲聲停下的時候，甲板上瀰漫著硝煙與海水的氣味。緋帆快船掛著兩道焦痕，不甘地掉頭撤退。",
+        goto: "n_effect_win",
+      },
+      {
+        kind: "dialogue",
+        id: "n_scar",
+        speaker: "旁白",
+        text: "海燕號的主帆又裂開了一道口子，但船還浮著，人一個沒少——這是不體面、卻活下來的一仗。",
+        goto: "n_effect_scar",
+      },
+      {
+        kind: "effect",
+        id: "n_effect_win",
+        effect: {
+          setFlags: ["flag.first_battle_done", "flag.first_battle_won"],
+          worldState: [{ path: "crimsonThreat", delta: 10 }],
+          unlock: { areas: ["area.perlan"], scenes: ["scene.perlan.docks"] },
+        },
+        goto: "n_end",
+      },
+      {
+        kind: "effect",
+        id: "n_effect_scar",
+        effect: {
+          setFlags: ["flag.first_battle_done", "flag.first_battle_fled"],
+          worldState: [{ path: "crimsonThreat", delta: 10 }],
+          unlock: { areas: ["area.perlan"], scenes: ["scene.perlan.docks"] },
+        },
+        goto: "n_end",
+      },
+      {
+        kind: "dialogue",
+        id: "n_end",
+        speaker: "布拉姆",
+        text: "「有個人站在船尾一直看著我們，」他抹了把臉上的硝煙，「像在記你的臉。」",
+        goto: "END",
+      },
+    ],
+  },
+};

--- a/azure-voyage/packages/rpg-content/src/events/opening.ts
+++ b/azure-voyage/packages/rpg-content/src/events/opening.ts
@@ -1,0 +1,88 @@
+import type { GameEvent } from "@azure-voyage/rpg-engine";
+
+/** 開場（docs/28 楔子改編）：港務廳掛名入行，取得起始委託。 */
+export const OPENING_EVENTS: Record<string, GameEvent> = {
+  "event.opening": {
+    id: "event.opening",
+    precondition: { kind: "always" },
+    weight: 100,
+    once: true,
+    entryNodeId: "n1",
+    nodes: [
+      {
+        kind: "dialogue",
+        id: "n1",
+        speaker: "旁白",
+        text: "奧雷利亞的清晨，是從鹽與松脂的氣味裡醒來的。你把父親留下的半張殘圖攤在港務廳的長桌上，指尖還在抖。",
+        goto: "n2",
+      },
+      {
+        kind: "dialogue",
+        id: "n2",
+        speaker: "馬瑟斯·凡登霍夫",
+        text: "「這種東西，我這輩子見過不下二十張。每一個拿著它來的人，都覺得自己跟別人不一樣。」",
+        goto: "n3",
+      },
+      {
+        kind: "choice",
+        id: "n3",
+        prompt: "你要怎麼回應？",
+        options: [
+          { label: "「那我就證明給你看。」", goto: "n_confident" },
+          { label: "什麼也不說，只是把圖收好", goto: "n_quiet" },
+        ],
+      },
+      {
+        kind: "dialogue",
+        id: "n_confident",
+        speaker: "馬瑟斯",
+        text: "老人看了你一眼，像是看慣了做夢的年輕人，卻沒有嘲笑的意思。「口氣不小。」",
+        goto: "n4",
+      },
+      {
+        kind: "dialogue",
+        id: "n_quiet",
+        speaker: "馬瑟斯",
+        text: "老人沒有追問，只是把一枚黃銅印信推過長桌。「不愛說話的人，通常撐得比較久。」",
+        goto: "n4",
+      },
+      {
+        kind: "dialogue",
+        id: "n4",
+        speaker: "馬瑟斯",
+        text: "「一艘縱帆船，停在西三號泊位，船況不算好。名字你自己取——晨汐商會，就這麼定了。」",
+        goto: "n5",
+      },
+      {
+        kind: "effect",
+        id: "n5",
+        effect: { setFlags: ["flag.game_started"], advanceTime: 1 },
+        goto: "n6",
+      },
+      {
+        kind: "dialogue",
+        id: "n6",
+        speaker: "馬瑟斯",
+        text: "「對了——最近別往灣口外面太遠的地方跑。緋帆團的巡哨船，這陣子出沒得勤。」",
+        goto: "END",
+      },
+    ],
+  },
+  "event.harbor_office.rumor": {
+    id: "event.harbor_office.rumor",
+    precondition: { kind: "flag", flag: "flag.game_started", value: true },
+    weight: 20,
+    once: false,
+    cooldownDays: 2,
+    entryNodeId: "n1",
+    nodes: [
+      {
+        kind: "dialogue",
+        id: "n1",
+        speaker: "公告欄",
+        text: "貼著幾張懸賞與航運告示，其中一張被人用炭筆潦草地補了一行字：「緋帆團又在灣口攔船了，各家船長自己小心。」",
+        goto: "END",
+      },
+    ],
+  },
+};

--- a/azure-voyage/packages/rpg-content/src/events/perlan.ts
+++ b/azure-voyage/packages/rpg-content/src/events/perlan.ts
@@ -1,0 +1,96 @@
+import type { GameEvent } from "@azure-voyage/rpg-engine";
+
+/** 佩爾蘭支線：老漁夫的家傳鹽田（docs/28 第四章改編；docs/27 支線清單）。 */
+export const PERLAN_EVENTS: Record<string, GameEvent> = {
+  "event.perlan.meet_tuk": {
+    id: "event.perlan.meet_tuk",
+    precondition: { kind: "always" },
+    weight: 100,
+    once: true,
+    entryNodeId: "n1",
+    nodes: [
+      {
+        kind: "dialogue",
+        id: "n1",
+        speaker: "旁白",
+        text: "一個老人坐在碼頭邊，望著一片荒廢的曬鹽場，眼神空得像退了潮的灘。",
+        goto: "n2",
+      },
+      {
+        kind: "dialogue",
+        id: "n2",
+        speaker: "圖克·佩蘭",
+        text: "「這幾年，來收鹽的越來越少了。那本來是全佩爾蘭最好的一塊鹽田，現在雜草比鹽還多。」",
+        goto: "n3",
+      },
+      {
+        kind: "choice",
+        id: "n3",
+        prompt: "你要怎麼回應？",
+        options: [
+          { label: "「我多收一點——往後每次經過都來補鹽，你把鹽田重新開起來。」", goto: "n_help" },
+          { label: "「我只是路過收鹽，幫不上這個忙。」", goto: "n_decline" },
+        ],
+      },
+      {
+        kind: "effect",
+        id: "n_help",
+        effect: { setFlags: ["flag.perlan_help_promised"], affinity: [{ npc: "npc.tuk", delta: 20 }] },
+        goto: "n_help_close",
+      },
+      {
+        kind: "dialogue",
+        id: "n_help_close",
+        speaker: "圖克·佩蘭",
+        text: "老人愣住了，隨即露出一個久違的笑：「你圖什麼？外來的商會不會做賠本生意。」你沒有回答，只是笑了笑。",
+        goto: "END",
+      },
+      {
+        kind: "effect",
+        id: "n_decline",
+        effect: { setFlags: ["flag.perlan_declined"], affinity: [{ npc: "npc.tuk", delta: 2 }] },
+        goto: "n_decline_close",
+      },
+      {
+        kind: "dialogue",
+        id: "n_decline_close",
+        speaker: "圖克·佩蘭",
+        text: "老人點點頭，沒有多說什麼，只是轉身望向那片荒鹽場，背影比方才更佝僂了一些。",
+        goto: "END",
+      },
+    ],
+  },
+  "event.perlan.saltfield_reopened": {
+    id: "event.perlan.saltfield_reopened",
+    precondition: { kind: "flag", flag: "flag.perlan_help_promised", value: true },
+    weight: 100,
+    once: true,
+    entryNodeId: "n1",
+    nodes: [
+      {
+        kind: "dialogue",
+        id: "n1",
+        speaker: "旁白",
+        text: "再訪佩爾蘭，那片荒廢的鹽田已經重新開了起來——圖克把家傳的曬鹽手藝，一點一點教回給村裡的年輕人。",
+        goto: "n2",
+      },
+      {
+        kind: "dialogue",
+        id: "n2",
+        speaker: "圖克·佩蘭",
+        text: "「這是頭一鍋。」老人往你手裡塞了一小袋雪白的鹽，「海給的東西，第一口最鮮。往後不管你在哪片海上，嚐到這口鹹，就想起佩爾蘭還有個老頭記著你。」",
+        goto: "n_close",
+      },
+      {
+        kind: "effect",
+        id: "n_close",
+        effect: {
+          setFlags: ["flag.perlan_quest_completed"],
+          giveItem: ["item.perlan_salt"],
+          reputation: [{ area: "area.perlan", delta: 10 }],
+        },
+        goto: "END",
+      },
+    ],
+  },
+};

--- a/azure-voyage/packages/rpg-content/src/events/tavern.ts
+++ b/azure-voyage/packages/rpg-content/src/events/tavern.ts
@@ -1,0 +1,134 @@
+import type { GameEvent } from "@azure-voyage/rpg-engine";
+
+/** 錨與星酒館：招募班底（docs/28 第三章改編）。 */
+export const TAVERN_EVENTS: Record<string, GameEvent> = {
+  "event.tavern.recruit_bram": {
+    id: "event.tavern.recruit_bram",
+    precondition: { kind: "and", all: [{ kind: "flag", flag: "flag.game_started", value: true }, { kind: "not", cond: { kind: "flag", flag: "flag.recruited_bram", value: true } }] },
+    weight: 100,
+    once: true,
+    entryNodeId: "n1",
+    nodes: [
+      {
+        kind: "dialogue",
+        id: "n1",
+        speaker: "旁白",
+        text: "角落坐著一個話少、手上有常年握舵磨出厚繭的漢子，正專注地擦拭一支老舊的六分儀。",
+        goto: "check_lead",
+      },
+      {
+        kind: "skillCheck",
+        id: "check_lead",
+        stat: "lead",
+        difficulty: 15,
+        onSuccess: "n_win",
+        onFailure: "n_hard",
+      },
+      {
+        kind: "dialogue",
+        id: "n_win",
+        speaker: "布拉姆·霍特",
+        text: "「你出海之前，讓我先看一遍你的索具。」他站起身，比你高出半個頭，「你叫什麼？」",
+        goto: "n_recruited",
+      },
+      {
+        kind: "dialogue",
+        id: "n_hard",
+        speaker: "布拉姆·霍特",
+        text: "他盯著你看了很久，才慢慢放下六分儀。「補過的帆，逆風時最容易再裂……好吧。我上船。」",
+        goto: "n_recruited",
+      },
+      {
+        kind: "effect",
+        id: "n_recruited",
+        effect: { setFlags: ["flag.recruited_bram"], affinity: [{ npc: "npc.bram", delta: 15 }] },
+        goto: "n_close",
+      },
+      {
+        kind: "dialogue",
+        id: "n_close",
+        speaker: "布拉姆·霍特",
+        text: "「掌過三條船的舵，沉過一條——那不是我的錯。走吧。」",
+        goto: "END",
+      },
+    ],
+  },
+  "event.tavern.recruit_sera": {
+    id: "event.tavern.recruit_sera",
+    precondition: { kind: "and", all: [{ kind: "flag", flag: "flag.recruited_bram", value: true }, { kind: "not", cond: { kind: "flag", flag: "flag.recruited_sera", value: true } }] },
+    weight: 100,
+    once: true,
+    entryNodeId: "n1",
+    nodes: [
+      {
+        kind: "dialogue",
+        id: "n1",
+        speaker: "旁白",
+        text: "吧檯另一頭，一個帳房出身的女人正把一本磨得起毛邊的帳冊拍在桌上，像是在跟誰賭氣。",
+        goto: "check_trade",
+      },
+      {
+        kind: "skillCheck",
+        id: "check_trade",
+        stat: "trade",
+        difficulty: 15,
+        onSuccess: "n_win",
+        onFailure: "n_hard",
+      },
+      {
+        kind: "dialogue",
+        id: "n_win",
+        speaker: "賽菈·凡德",
+        text: "「鎏金天秤只在乎錢。你會嗎？」她盯著你，等你回答的樣子讓人無處可躲。",
+        goto: "n_answer",
+      },
+      {
+        kind: "dialogue",
+        id: "n_hard",
+        speaker: "賽菈·凡德",
+        text: "她皺著眉，把帳冊翻了好幾頁才抬頭。「你這條船，帳算得清楚嗎？」",
+        goto: "n_answer",
+      },
+      {
+        kind: "dialogue",
+        id: "n_answer",
+        speaker: "你",
+        text: "「我不知道。但我會盡量不把人當算盤珠子撥。」",
+        goto: "n_recruited",
+      },
+      {
+        kind: "effect",
+        id: "n_recruited",
+        effect: {
+          setFlags: ["flag.recruited_sera", "flag.crew_assembled"],
+          affinity: [{ npc: "npc.sera", delta: 15 }],
+        },
+        goto: "n_close",
+      },
+      {
+        kind: "dialogue",
+        id: "n_close",
+        speaker: "賽菈·凡德",
+        text: "「這個回答比『不會』誠實。」她合上帳冊，「我跟你走。」",
+        goto: "END",
+      },
+    ],
+  },
+  "event.tavern.crimson_rumor": {
+    id: "event.tavern.crimson_rumor",
+    precondition: { kind: "flag", flag: "flag.game_started", value: true },
+    weight: 15,
+    once: false,
+    cooldownDays: 2,
+    entryNodeId: "n1",
+    nodes: [
+      {
+        kind: "dialogue",
+        id: "n1",
+        speaker: "旁白",
+        text: "隔壁桌的水手壓低聲音議論：「聽說緋帆團上個月在灣口劫了一條運鹽船，船上的人一個沒傷，貨卻搬得一乾二淨。」",
+        goto: "END",
+      },
+    ],
+  },
+};

--- a/azure-voyage/packages/rpg-content/src/index.ts
+++ b/azure-voyage/packages/rpg-content/src/index.ts
@@ -1,0 +1,1 @@
+export { AZURE_VOYAGE_RPG_CONTENT, createStartState } from "./content";

--- a/azure-voyage/packages/rpg-content/src/npcs.ts
+++ b/azure-voyage/packages/rpg-content/src/npcs.ts
@@ -1,0 +1,36 @@
+import type { Npc } from "@azure-voyage/rpg-engine";
+
+/**
+ * P1/P2 垂直切片人物（docs/28《蒼瀾航路》第一部）。好感階段沿用 docs/29 §5
+ * 的設計，但目前的事件內容還沒把每一階都寫滿——先把骨架接好，之後補內容
+ * 只需要在 affinityTiers 加項目、寫對應事件，不用碰引擎或這裡的其他人物。
+ */
+export const NPCS: Record<string, Npc> = {
+  "npc.mathers": {
+    id: "npc.mathers",
+    name: "馬瑟斯·凡登霍夫",
+    portrait: "portrait.notable_aurelia",
+    homeScene: "scene.aurelia.harbor_office",
+  },
+  "npc.bram": {
+    id: "npc.bram",
+    name: "布拉姆·霍特",
+    portrait: "portrait.officer_generic_1",
+    homeScene: "scene.aurelia.tavern",
+    affinityTiers: [{ threshold: 15, unlockEvents: [] }],
+  },
+  "npc.sera": {
+    id: "npc.sera",
+    name: "賽菈·凡德",
+    portrait: "portrait.officer_generic_2",
+    homeScene: "scene.aurelia.tavern",
+    affinityTiers: [{ threshold: 15, unlockEvents: [] }],
+  },
+  "npc.tuk": {
+    id: "npc.tuk",
+    name: "圖克·佩蘭",
+    portrait: "portrait.notable_perlan",
+    homeScene: "scene.perlan.docks",
+    affinityTiers: [{ threshold: 20, unlockEvents: ["event.perlan.saltfield_reopened"] }],
+  },
+};

--- a/azure-voyage/packages/rpg-content/src/quests.ts
+++ b/azure-voyage/packages/rpg-content/src/quests.ts
@@ -1,0 +1,71 @@
+import type { Quest } from "@azure-voyage/rpg-engine";
+
+/**
+ * 主線第一部（docs/28 第一部）+ 佩爾蘭支線的任務宣告。目標判定沿用 M28
+ * QuestService「用既有可查詢狀態」的哲學——這裡全部讀事件留下的 flag，
+ * 不需要另外的計數器。獎勵已經在完成任務的事件 effect 節點裡直接發放
+ * （見 events/*.ts），這裡的 rewards 欄位純粹是任務面板顯示用的文案來源，
+ * 引擎不會自動套用它——避免重複發放。
+ */
+export const QUESTS: Record<string, Quest> = {
+  "quest.ch1_first_trade": {
+    id: "quest.ch1_first_trade",
+    kind: "MAIN",
+    title: "初出茅廬",
+    giver: "npc.mathers",
+    precondition: { kind: "flag", flag: "flag.game_started", value: true },
+    objectives: [
+      {
+        id: "obj.first_trade",
+        description: "在中央市場完成第一筆交易",
+        completeWhen: { kind: "flag", flag: "flag.first_trade_done", value: true },
+      },
+    ],
+    rewards: {},
+  },
+  "quest.ch2_crew": {
+    id: "quest.ch2_crew",
+    kind: "MAIN",
+    title: "組建班底",
+    giver: "npc.mathers",
+    precondition: { kind: "flag", flag: "flag.game_started", value: true },
+    objectives: [
+      {
+        id: "obj.recruit_crew",
+        description: "在錨與星酒館招募滿 2 名班底",
+        completeWhen: { kind: "flag", flag: "flag.crew_assembled", value: true },
+      },
+    ],
+    rewards: {},
+  },
+  "quest.ch3_first_battle": {
+    id: "quest.ch3_first_battle",
+    kind: "MAIN",
+    title: "海上見真章",
+    giver: "npc.mathers",
+    precondition: { kind: "flag", flag: "flag.crew_assembled", value: true },
+    objectives: [
+      {
+        id: "obj.first_battle",
+        description: "頂住緋帆團的第一次試探",
+        completeWhen: { kind: "flag", flag: "flag.first_battle_done", value: true },
+      },
+    ],
+    rewards: {},
+  },
+  "quest.side_perlan": {
+    id: "quest.side_perlan",
+    kind: "SIDE",
+    title: "老漁夫的家傳鹽田",
+    giver: "npc.tuk",
+    precondition: { kind: "flag", flag: "flag.perlan_help_promised", value: true },
+    objectives: [
+      {
+        id: "obj.reopen_saltfield",
+        description: "再訪佩爾蘭，看看鹽田重開的結果",
+        completeWhen: { kind: "flag", flag: "flag.perlan_quest_completed", value: true },
+      },
+    ],
+    rewards: {},
+  },
+};

--- a/azure-voyage/packages/rpg-content/src/regionsAreas.ts
+++ b/azure-voyage/packages/rpg-content/src/regionsAreas.ts
@@ -1,0 +1,31 @@
+import type { Area, WorldRegion } from "@azure-voyage/rpg-engine";
+
+export const REGIONS: Record<string, WorldRegion> = {
+  "region.amber_gulf": {
+    id: "region.amber_gulf",
+    name: "琥珀灣",
+    unlockCondition: { kind: "always" },
+    areas: ["area.aurelia", "area.perlan"],
+  },
+};
+
+export const AREAS: Record<string, Area> = {
+  "area.aurelia": {
+    id: "area.aurelia",
+    regionId: "region.amber_gulf",
+    name: "奧雷利亞",
+    kind: "PORT",
+    unlockCondition: { kind: "always" },
+    scenes: ["scene.aurelia.harbor_office", "scene.aurelia.tavern", "scene.aurelia.market"],
+  },
+  // 佩爾蘭在小說第四章登場——凡恩組好班底、在奧雷利亞站穩腳跟後才順道繞去補鹽。
+  // 用 flag.crew_assembled 當解鎖條件，呼應這個敘事順序（見 events/tavern.ts）。
+  "area.perlan": {
+    id: "area.perlan",
+    regionId: "region.amber_gulf",
+    name: "佩爾蘭",
+    kind: "PORT",
+    unlockCondition: { kind: "flag", flag: "flag.crew_assembled", value: true },
+    scenes: ["scene.perlan.docks"],
+  },
+};

--- a/azure-voyage/packages/rpg-content/src/scenes/aurelia.ts
+++ b/azure-voyage/packages/rpg-content/src/scenes/aurelia.ts
@@ -1,0 +1,63 @@
+import type { Scene } from "@azure-voyage/rpg-engine";
+
+export const AURELIA_SCENES: Record<string, Scene> = {
+  "scene.aurelia.harbor_office": {
+    id: "scene.aurelia.harbor_office",
+    areaId: "area.aurelia",
+    name: "港務廳",
+    timeGate: { phases: ["DAWN", "DAY", "DUSK"] }, // 夜裡不辦公
+    hotspots: [
+      {
+        id: "hotspot.harbor_office.desk",
+        label: "長桌前的馬瑟斯",
+        eventPool: ["event.opening"],
+      },
+      {
+        id: "hotspot.harbor_office.notice_board",
+        label: "公告欄",
+        eventPool: ["event.harbor_office.rumor"],
+        visibleIf: { kind: "flag", flag: "flag.game_started", value: true },
+      },
+    ],
+  },
+  "scene.aurelia.tavern": {
+    id: "scene.aurelia.tavern",
+    areaId: "area.aurelia",
+    name: "錨與星酒館",
+    timeGate: { phases: ["DUSK", "NIGHT"] }, // 傍晚才開始熱鬧
+    hotspots: [
+      {
+        id: "hotspot.tavern.bar",
+        label: "吧檯",
+        eventPool: ["event.tavern.recruit_bram", "event.tavern.recruit_sera"],
+        visibleIf: { kind: "flag", flag: "flag.game_started", value: true },
+      },
+      {
+        id: "hotspot.tavern.corner_table",
+        label: "角落的桌子",
+        eventPool: ["event.tavern.crimson_rumor"],
+        visibleIf: { kind: "flag", flag: "flag.game_started", value: true },
+      },
+    ],
+  },
+  "scene.aurelia.market": {
+    id: "scene.aurelia.market",
+    areaId: "area.aurelia",
+    name: "中央市場",
+    timeGate: { phases: ["DAWN", "DAY"] }, // 只在白天營業
+    hotspots: [
+      {
+        id: "hotspot.market.stalls",
+        label: "貨攤",
+        eventPool: ["event.market.first_trade"],
+        visibleIf: { kind: "flag", flag: "flag.game_started", value: true },
+      },
+      {
+        id: "hotspot.market.lookout",
+        label: "碼頭瞭望",
+        eventPool: ["event.market.crimson_scout"],
+        visibleIf: { kind: "flag", flag: "flag.crew_assembled", value: true },
+      },
+    ],
+  },
+};

--- a/azure-voyage/packages/rpg-content/src/scenes/perlan.ts
+++ b/azure-voyage/packages/rpg-content/src/scenes/perlan.ts
@@ -1,0 +1,16 @@
+import type { Scene } from "@azure-voyage/rpg-engine";
+
+export const PERLAN_SCENES: Record<string, Scene> = {
+  "scene.perlan.docks": {
+    id: "scene.perlan.docks",
+    areaId: "area.perlan",
+    name: "佩爾蘭碼頭",
+    hotspots: [
+      {
+        id: "hotspot.perlan.old_fisherman",
+        label: "老漁夫圖克",
+        eventPool: ["event.perlan.meet_tuk", "event.perlan.saltfield_reopened"],
+      },
+    ],
+  },
+};

--- a/azure-voyage/packages/rpg-content/tsconfig.json
+++ b/azure-voyage/packages/rpg-content/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@azure-voyage/tsconfig/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/azure-voyage/packages/rpg-engine/package.json
+++ b/azure-voyage/packages/rpg-engine/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@azure-voyage/rpg-engine",
+  "version": "0.1.0",
+  "private": true,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -p tsconfig.json --watch --preserveWatchOutput",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@azure-voyage/tsconfig": "workspace:*",
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.8"
+  }
+}

--- a/azure-voyage/packages/rpg-engine/src/condition.test.ts
+++ b/azure-voyage/packages/rpg-engine/src/condition.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { evaluateCondition } from "./condition";
+import { createInitialSaveState, type SaveState } from "./types";
+
+function baseState(overrides: Partial<SaveState> = {}): SaveState {
+  return {
+    ...createInitialSaveState({ startSceneId: "s1", startAreaId: "a1", startRegionId: "r1" }),
+    ...overrides,
+  };
+}
+
+describe("evaluateCondition", () => {
+  it("always is true", () => {
+    expect(evaluateCondition({ kind: "always" }, baseState())).toBe(true);
+  });
+
+  it("flag matches presence/absence", () => {
+    const state = baseState({ flags: ["flag.met_kohl"] });
+    expect(evaluateCondition({ kind: "flag", flag: "flag.met_kohl", value: true }, state)).toBe(true);
+    expect(evaluateCondition({ kind: "flag", flag: "flag.met_kohl", value: false }, state)).toBe(false);
+    expect(evaluateCondition({ kind: "flag", flag: "flag.other", value: false }, state)).toBe(true);
+  });
+
+  it("worldState reads nested path with dot notation", () => {
+    const state = baseState();
+    state.worldState.guildOrder["npc.crimson_sails"] = 55;
+    expect(
+      evaluateCondition({ kind: "worldState", path: "guildOrder.npc.crimson_sails", op: ">=", value: 50 }, state),
+    ).toBe(true);
+    expect(
+      evaluateCondition({ kind: "worldState", path: "guildOrder.npc.crimson_sails", op: ">=", value: 60 }, state),
+    ).toBe(false);
+    expect(evaluateCondition({ kind: "worldState", path: "seaOmen", op: "==", value: "CALM" }, state)).toBe(true);
+  });
+
+  it("stat/affinity/reputation/exploration compare with defaults of 0", () => {
+    const state = baseState();
+    expect(evaluateCondition({ kind: "stat", stat: "lore", op: ">=", value: 20 }, state)).toBe(true);
+    expect(evaluateCondition({ kind: "affinity", npc: "npc.kohl", op: ">=", value: 1 }, state)).toBe(false);
+    state.affinity["npc.kohl"] = 40;
+    expect(evaluateCondition({ kind: "affinity", npc: "npc.kohl", op: ">=", value: 40 }, state)).toBe(true);
+  });
+
+  it("time window checks phase/season/day range", () => {
+    const state = baseState();
+    state.clock = { day: 5, phase: "NIGHT", season: "SUMMER" };
+    expect(evaluateCondition({ kind: "time", window: { phases: ["NIGHT"] } }, state)).toBe(true);
+    expect(evaluateCondition({ kind: "time", window: { phases: ["DAY"] } }, state)).toBe(false);
+    expect(evaluateCondition({ kind: "time", window: { minDay: 10 } }, state)).toBe(false);
+    expect(evaluateCondition({ kind: "time", window: { minDay: 1, maxDay: 10 } }, state)).toBe(true);
+  });
+
+  it("eventCompleted checks history count", () => {
+    const state = baseState();
+    expect(evaluateCondition({ kind: "eventCompleted", event: "event.x" }, state)).toBe(false);
+    state.eventHistory["event.x"] = { count: 1, lastAtDay: 1 };
+    expect(evaluateCondition({ kind: "eventCompleted", event: "event.x" }, state)).toBe(true);
+  });
+
+  it("and/or/not combinators", () => {
+    const state = baseState({ flags: ["flag.a"] });
+    expect(
+      evaluateCondition(
+        { kind: "and", all: [{ kind: "flag", flag: "flag.a", value: true }, { kind: "always" }] },
+        state,
+      ),
+    ).toBe(true);
+    expect(
+      evaluateCondition(
+        { kind: "or", any: [{ kind: "flag", flag: "flag.b", value: true }, { kind: "flag", flag: "flag.a", value: true }] },
+        state,
+      ),
+    ).toBe(true);
+    expect(evaluateCondition({ kind: "not", cond: { kind: "flag", flag: "flag.a", value: true } }, state)).toBe(
+      false,
+    );
+  });
+});

--- a/azure-voyage/packages/rpg-engine/src/condition.ts
+++ b/azure-voyage/packages/rpg-engine/src/condition.ts
@@ -1,0 +1,66 @@
+import type { Condition, SaveState, TimeWindow } from "./types";
+
+/**
+ * worldState 路徑最多兩層：欄位名 + 選填的 record 鍵。鍵本身可能含有點
+ * （例如 "npc.crimson_sails"），所以只在第一個點切一刀，其餘原樣當鍵，
+ * 不能用 `.split(".")` 遞迴切——那會把 "npc.crimson_sails" 誤拆成三段。
+ */
+function splitPath(path: string): [string, string | undefined] {
+  const idx = path.indexOf(".");
+  if (idx === -1) return [path, undefined];
+  return [path.slice(0, idx), path.slice(idx + 1)];
+}
+
+function getPath(obj: unknown, path: string): unknown {
+  const [field, rest] = splitPath(path);
+  if (obj === null || typeof obj !== "object") return undefined;
+  const value = (obj as Record<string, unknown>)[field];
+  if (rest === undefined) return value;
+  if (value === null || typeof value !== "object") return undefined;
+  return (value as Record<string, unknown>)[rest];
+}
+
+function compare(actual: unknown, op: ">=" | "<=" | "==", expected: number | string): boolean {
+  if (op === "==") return actual === expected;
+  if (typeof actual !== "number" || typeof expected !== "number") return false;
+  return op === ">=" ? actual >= expected : actual <= expected;
+}
+
+function matchesTimeWindow(window: TimeWindow, state: SaveState): boolean {
+  const { day, phase, season } = state.clock;
+  if (window.phases && !window.phases.includes(phase)) return false;
+  if (window.seasons && !window.seasons.includes(season)) return false;
+  if (window.minDay !== undefined && day < window.minDay) return false;
+  if (window.maxDay !== undefined && day > window.maxDay) return false;
+  return true;
+}
+
+/** 統一條件求值——所有系統（事件/場景/NPC/任務）都用它決定能不能觸發/顯示。 */
+export function evaluateCondition(cond: Condition, state: SaveState): boolean {
+  switch (cond.kind) {
+    case "always":
+      return true;
+    case "flag":
+      return state.flags.includes(cond.flag) === cond.value;
+    case "worldState":
+      return compare(getPath(state.worldState, cond.path), cond.op, cond.value);
+    case "affinity":
+      return (state.affinity[cond.npc] ?? 0) >= cond.value;
+    case "stat":
+      return state.captainStats[cond.stat] >= cond.value;
+    case "reputation":
+      return (state.reputation[cond.area] ?? 0) >= cond.value;
+    case "exploration":
+      return (state.exploration[cond.area] ?? 0) >= cond.value;
+    case "eventCompleted":
+      return (state.eventHistory[cond.event]?.count ?? 0) > 0;
+    case "time":
+      return matchesTimeWindow(cond.window, state);
+    case "and":
+      return cond.all.every((c) => evaluateCondition(c, state));
+    case "or":
+      return cond.any.some((c) => evaluateCondition(c, state));
+    case "not":
+      return !evaluateCondition(cond.cond, state);
+  }
+}

--- a/azure-voyage/packages/rpg-engine/src/effect.test.ts
+++ b/azure-voyage/packages/rpg-engine/src/effect.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { advanceClock, applyEffect } from "./effect";
+import { createInitialSaveState } from "./types";
+
+function baseState() {
+  return createInitialSaveState({ startSceneId: "s1", startAreaId: "a1", startRegionId: "r1" });
+}
+
+describe("applyEffect", () => {
+  it("adds flags without duplicates and does not mutate input", () => {
+    const state = baseState();
+    const next = applyEffect({ setFlags: ["flag.a"] }, state);
+    expect(state.flags).toEqual([]);
+    expect(next.flags).toEqual(["flag.a"]);
+    const next2 = applyEffect({ setFlags: ["flag.a", "flag.b"] }, next);
+    expect(next2.flags).toEqual(["flag.a", "flag.b"]);
+  });
+
+  it("applies worldState delta and set at nested paths", () => {
+    const state = baseState();
+    const next = applyEffect({ worldState: [{ path: "crimsonThreat", delta: 10 }] }, state);
+    expect(next.worldState.crimsonThreat).toBe(10);
+    const next2 = applyEffect({ worldState: [{ path: "guildOrder.npc.crimson_sails", set: 30 }] }, next);
+    expect(next2.worldState.guildOrder["npc.crimson_sails"]).toBe(30);
+    const next3 = applyEffect({ worldState: [{ path: "guildOrder.npc.crimson_sails", delta: 5 }] }, next2);
+    expect(next3.worldState.guildOrder["npc.crimson_sails"]).toBe(35);
+  });
+
+  it("accumulates affinity and reputation deltas", () => {
+    const state = baseState();
+    const next = applyEffect(
+      { affinity: [{ npc: "npc.kohl", delta: 15 }], reputation: [{ area: "area.aurelia", delta: 5 }] },
+      state,
+    );
+    expect(next.affinity["npc.kohl"]).toBe(15);
+    expect(next.reputation["area.aurelia"]).toBe(5);
+    const next2 = applyEffect({ affinity: [{ npc: "npc.kohl", delta: 5 }] }, next);
+    expect(next2.affinity["npc.kohl"]).toBe(20);
+  });
+
+  it("unlocks regions/areas/scenes without duplication", () => {
+    const state = baseState();
+    const next = applyEffect({ unlock: { areas: ["area.perlan"], scenes: ["scene.perlan.docks"] } }, state);
+    expect(next.unlocked.areas).toContain("area.perlan");
+    expect(next.unlocked.scenes).toContain("scene.perlan.docks");
+    const next2 = applyEffect({ unlock: { areas: ["area.perlan"] } }, next);
+    expect(next2.unlocked.areas.filter((a) => a === "area.perlan")).toHaveLength(1);
+  });
+
+  it("advances clock through phases into the next day", () => {
+    const state = baseState();
+    expect(state.clock).toEqual({ day: 1, phase: "DAWN", season: "SPRING" });
+    const next = applyEffect({ advanceTime: 1 }, state);
+    expect(next.clock.phase).toBe("DAY");
+    expect(next.clock.day).toBe(1);
+    const next2 = applyEffect({ advanceTime: 4 }, next);
+    expect(next2.clock).toEqual({ day: 2, phase: "DAY", season: "SPRING" });
+  });
+
+  it("gives items", () => {
+    const state = baseState();
+    const next = applyEffect({ giveItem: ["item.perlan_salt"] }, state);
+    expect(next.inventory).toEqual(["item.perlan_salt"]);
+  });
+});
+
+describe("advanceClock", () => {
+  it("wraps phase index and increments day on rollover", () => {
+    const clock = advanceClock({ day: 1, phase: "NIGHT", season: "SPRING" }, 1);
+    expect(clock).toEqual({ day: 2, phase: "DAWN", season: "SPRING" });
+  });
+});

--- a/azure-voyage/packages/rpg-engine/src/effect.ts
+++ b/azure-voyage/packages/rpg-engine/src/effect.ts
@@ -1,0 +1,95 @@
+import { GAME_PHASES, type Effect, type GameClock, type SaveState } from "./types";
+
+/** worldState 路徑最多兩層，見 condition.ts 的同名說明——鍵本身可能含點。 */
+function splitPath(path: string): [string, string | undefined] {
+  const idx = path.indexOf(".");
+  if (idx === -1) return [path, undefined];
+  return [path.slice(0, idx), path.slice(idx + 1)];
+}
+
+function getPath(obj: unknown, path: string): unknown {
+  const [field, rest] = splitPath(path);
+  if (obj === null || typeof obj !== "object") return undefined;
+  const value = (obj as Record<string, unknown>)[field];
+  if (rest === undefined) return value;
+  if (value === null || typeof value !== "object") return undefined;
+  return (value as Record<string, unknown>)[rest];
+}
+
+function setPath(obj: Record<string, unknown>, path: string, value: unknown): void {
+  const [field, rest] = splitPath(path);
+  if (rest === undefined) {
+    obj[field] = value;
+    return;
+  }
+  if (typeof obj[field] !== "object" || obj[field] === null) obj[field] = {};
+  (obj[field] as Record<string, unknown>)[rest] = value;
+}
+
+/** 推進時段：DAWN→DAY→DUSK→NIGHT→隔天 DAWN。 */
+export function advanceClock(clock: GameClock, steps: number): GameClock {
+  let phaseIndex = GAME_PHASES.indexOf(clock.phase);
+  let day = clock.day;
+  for (let i = 0; i < steps; i++) {
+    phaseIndex += 1;
+    if (phaseIndex >= GAME_PHASES.length) {
+      phaseIndex = 0;
+      day += 1;
+    }
+  }
+  return { ...clock, day, phase: GAME_PHASES[phaseIndex] };
+}
+
+function unique(list: string[]): string[] {
+  return [...new Set(list)];
+}
+
+/** 統一後果套用——事件/任務獎勵都用它改變存檔狀態。回傳新的 SaveState（不修改輸入）。 */
+export function applyEffect(effect: Effect, state: SaveState): SaveState {
+  const next: SaveState = {
+    ...state,
+    flags: [...state.flags],
+    worldState: JSON.parse(JSON.stringify(state.worldState)),
+    affinity: { ...state.affinity },
+    reputation: { ...state.reputation },
+    exploration: { ...state.exploration },
+    inventory: [...state.inventory],
+    unlocked: {
+      regions: [...state.unlocked.regions],
+      areas: [...state.unlocked.areas],
+      scenes: [...state.unlocked.scenes],
+    },
+  };
+
+  for (const flag of effect.setFlags ?? []) {
+    if (!next.flags.includes(flag)) next.flags.push(flag);
+  }
+
+  for (const w of effect.worldState ?? []) {
+    if (w.set !== undefined) {
+      setPath(next.worldState as unknown as Record<string, unknown>, w.path, w.set);
+    } else {
+      const current = getPath(next.worldState, w.path);
+      const base = typeof current === "number" ? current : 0;
+      setPath(next.worldState as unknown as Record<string, unknown>, w.path, base + (w.delta ?? 0));
+    }
+  }
+
+  for (const a of effect.affinity ?? []) {
+    next.affinity[a.npc] = (next.affinity[a.npc] ?? 0) + a.delta;
+  }
+
+  for (const r of effect.reputation ?? []) {
+    next.reputation[r.area] = (next.reputation[r.area] ?? 0) + r.delta;
+  }
+
+  if (effect.unlock?.regions) next.unlocked.regions = unique([...next.unlocked.regions, ...effect.unlock.regions]);
+  if (effect.unlock?.areas) next.unlocked.areas = unique([...next.unlocked.areas, ...effect.unlock.areas]);
+  if (effect.unlock?.scenes) next.unlocked.scenes = unique([...next.unlocked.scenes, ...effect.unlock.scenes]);
+
+  if (effect.advanceTime) next.clock = advanceClock(next.clock, effect.advanceTime);
+
+  if (effect.giveItem) next.inventory.push(...effect.giveItem);
+
+  return next;
+}

--- a/azure-voyage/packages/rpg-engine/src/engine.test.ts
+++ b/azure-voyage/packages/rpg-engine/src/engine.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from "vitest";
+import { RpgEngine, pickEligibleEvent } from "./engine";
+import { validateContent } from "./validate";
+import { createInitialSaveState, type ContentPack, type GameEvent, type Hotspot, type SaveState } from "./types";
+
+function testContent(): ContentPack {
+  const greetEvent: GameEvent = {
+    id: "event.greet",
+    precondition: { kind: "always" },
+    weight: 1,
+    once: true,
+    entryNodeId: "n1",
+    nodes: [
+      { kind: "dialogue", id: "n1", speaker: "馬瑟斯", text: "歡迎來到奧雷利亞。", goto: "n2" },
+      {
+        kind: "choice",
+        id: "n2",
+        prompt: "你要？",
+        options: [
+          { label: "接下委託", goto: "n3" },
+          { label: "先離開", goto: "n4" },
+        ],
+      },
+      {
+        kind: "effect",
+        id: "n3",
+        effect: { setFlags: ["flag.took_job"], affinity: [{ npc: "npc.mathers", delta: 10 }] },
+        goto: "n5",
+      },
+      { kind: "dialogue", id: "n5", speaker: "馬瑟斯", text: "很好，出發吧。", goto: "END" },
+      { kind: "dialogue", id: "n4", speaker: "旁白", text: "你轉身離開了。", goto: "END" },
+    ],
+  };
+
+  const skillEvent: GameEvent = {
+    id: "event.skill_check",
+    precondition: { kind: "flag", flag: "flag.took_job", value: true },
+    weight: 1,
+    once: false,
+    cooldownDays: 1,
+    entryNodeId: "c1",
+    nodes: [
+      { kind: "skillCheck", id: "c1", stat: "lore", difficulty: 5, onSuccess: "c_win", onFailure: "c_lose" },
+      { kind: "dialogue", id: "c_win", speaker: "旁白", text: "你看懂了。", goto: "END" },
+      { kind: "dialogue", id: "c_lose", speaker: "旁白", text: "你沒看懂。", goto: "END" },
+    ],
+  };
+
+  const rareEvent: GameEvent = {
+    id: "event.rare",
+    precondition: { kind: "always" },
+    weight: 0,
+    once: false,
+    entryNodeId: "r1",
+    nodes: [{ kind: "dialogue", id: "r1", speaker: "旁白", text: "稀有事件。", goto: "END" }],
+  };
+
+  const hotspot: Hotspot = {
+    id: "hotspot.desk",
+    label: "港務廳長桌",
+    eventPool: ["event.greet", "event.skill_check", "event.rare"],
+  };
+
+  return {
+    regions: {
+      "region.amber_gulf": { id: "region.amber_gulf", name: "琥珀灣", unlockCondition: { kind: "always" }, areas: ["area.aurelia"] },
+    },
+    areas: {
+      "area.aurelia": {
+        id: "area.aurelia",
+        regionId: "region.amber_gulf",
+        name: "奧雷利亞",
+        kind: "PORT",
+        unlockCondition: { kind: "always" },
+        scenes: ["scene.aurelia.harbor_office"],
+      },
+    },
+    scenes: {
+      "scene.aurelia.harbor_office": {
+        id: "scene.aurelia.harbor_office",
+        areaId: "area.aurelia",
+        name: "港務廳",
+        hotspots: [hotspot],
+      },
+    },
+    events: { [greetEvent.id]: greetEvent, [skillEvent.id]: skillEvent, [rareEvent.id]: rareEvent },
+    npcs: {},
+    quests: {},
+    startSceneId: "scene.aurelia.harbor_office",
+  };
+}
+
+function newState(): SaveState {
+  return createInitialSaveState({
+    startSceneId: "scene.aurelia.harbor_office",
+    startAreaId: "area.aurelia",
+    startRegionId: "region.amber_gulf",
+  });
+}
+
+describe("validateContent", () => {
+  it("passes for a well-formed content pack", () => {
+    expect(validateContent(testContent())).toEqual([]);
+  });
+
+  it("catches dangling references", () => {
+    const content = testContent();
+    content.scenes["scene.aurelia.harbor_office"].hotspots[0].eventPool.push("event.missing");
+    const errors = validateContent(content);
+    expect(errors.some((e) => e.includes("event.missing"))).toBe(true);
+  });
+});
+
+describe("pickEligibleEvent", () => {
+  it("never picks a zero-weight event and respects preconditions", () => {
+    const content = testContent();
+    const hotspot = content.scenes["scene.aurelia.harbor_office"].hotspots[0];
+    const state = newState();
+    for (let i = 0; i < 20; i++) {
+      const ev = pickEligibleEvent(hotspot, content, state, Math.random);
+      expect(ev?.id).not.toBe("event.rare");
+      // skill_check 尚未滿足 precondition（flag.took_job 未設），只剩 greet 可選
+      expect(ev?.id).toBe("event.greet");
+    }
+  });
+});
+
+describe("RpgEngine time gating", () => {
+  it("reports scenes as closed outside their timeGate and blocks travelTo", () => {
+    const content = testContent();
+    content.scenes["scene.aurelia.harbor_office"].timeGate = { phases: ["DAWN", "DAY"] };
+    const engine = new RpgEngine(content, { ...newState(), clock: { day: 1, phase: "NIGHT", season: "SPRING" } });
+
+    const view = engine.getAreaView("area.aurelia");
+    expect(view.scenes[0].open).toBe(false);
+    expect(() => engine.travelTo("scene.aurelia.harbor_office")).toThrow();
+  });
+
+  it("allows travel once the clock is inside the timeGate", () => {
+    const content = testContent();
+    content.scenes["scene.aurelia.harbor_office"].timeGate = { phases: ["DAWN", "DAY"] };
+    const engine = new RpgEngine(content, { ...newState(), clock: { day: 1, phase: "DAY", season: "SPRING" } });
+
+    expect(engine.getAreaView("area.aurelia").scenes[0].open).toBe(true);
+    expect(() => engine.travelTo("scene.aurelia.harbor_office")).not.toThrow();
+  });
+});
+
+describe("RpgEngine full playthrough", () => {
+  it("plays through dialogue -> choice -> effect -> dialogue -> end, applying effects", () => {
+    const engine = new RpgEngine(testContent(), newState(), () => 0);
+    let node = engine.interact("hotspot.desk");
+    expect(node?.kind).toBe("dialogue");
+    node = engine.continue();
+    expect(node?.kind).toBe("choice");
+    if (node?.kind !== "choice") throw new Error("expected choice");
+    expect(node.options.map((o) => o.label)).toEqual(["接下委託", "先離開"]);
+
+    node = engine.choose(0); // 接下委託
+    expect(node.kind).toBe("dialogue");
+    node = engine.continue();
+    expect(node.kind).toBe("end");
+
+    expect(engine.state.flags).toContain("flag.took_job");
+    expect(engine.state.affinity["npc.mathers"]).toBe(10);
+    expect(engine.state.eventHistory["event.greet"].count).toBe(1);
+  });
+
+  it("does not re-offer a once event on the second interaction", () => {
+    const engine = new RpgEngine(testContent(), newState(), () => 0);
+    let node = engine.interact("hotspot.desk");
+    node = engine.continue();
+    node = engine.choose(1); // 先離開
+    node = engine.continue();
+    expect(node.kind).toBe("end");
+
+    // 第二次互動：greet 已完成（once），現在 flag.took_job 仍未設（選了離開），
+    // skill_check 前置條件不成立，rare 權重 0 —— 應該沒有事件可觸發。
+    const second = engine.interact("hotspot.desk");
+    expect(second).toBeNull();
+  });
+
+  it("resolves a skill check deterministically via injected rng", () => {
+    // 排除 event.greet（once 已完成）讓熱點只剩 event.skill_check 可抽,
+    // 才能確定性地測到判定節點,不受「兩個事件都符合條件時隨機抽中誰」影響。
+    const stateWithJob = (): SaveState => ({
+      ...newState(),
+      flags: ["flag.took_job"],
+      eventHistory: { "event.greet": { count: 1, lastAtDay: 1 } },
+    });
+
+    // rng() 恆回傳 1 → spread = floor(1*21)-10 = 11，lore(20)+11=31 >= difficulty(5) → 成功
+    const winEngine = new RpgEngine(testContent(), stateWithJob(), () => 1);
+    const win = winEngine.interact("hotspot.desk");
+    expect(win?.kind).toBe("checkResult");
+    if (win?.kind !== "checkResult") throw new Error("expected checkResult");
+    expect(win.success).toBe(true);
+    const after = winEngine.continue();
+    expect(after.kind).toBe("dialogue");
+
+    // 改用高難度事件驗證失敗路徑
+    const content = testContent();
+    content.events["event.skill_check"].nodes[0] = {
+      kind: "skillCheck",
+      id: "c1",
+      stat: "lore",
+      difficulty: 50,
+      onSuccess: "c_win",
+      onFailure: "c_lose",
+    };
+    const loseEngine = new RpgEngine(content, stateWithJob(), () => 0);
+    const lose = loseEngine.interact("hotspot.desk");
+    expect(lose?.kind).toBe("checkResult");
+    if (lose?.kind !== "checkResult") throw new Error("expected checkResult");
+    expect(lose.success).toBe(false);
+  });
+});

--- a/azure-voyage/packages/rpg-engine/src/engine.ts
+++ b/azure-voyage/packages/rpg-engine/src/engine.ts
@@ -1,0 +1,284 @@
+import { evaluateCondition } from "./condition";
+import { applyEffect } from "./effect";
+import type {
+  Area,
+  CaptainStat,
+  ContentPack,
+  EventNode,
+  GameEvent,
+  Hotspot,
+  Scene,
+  SaveState,
+  WorldRegion,
+} from "./types";
+
+export interface SceneView {
+  scene: Scene;
+  hotspots: Hotspot[]; // 已依 visibleIf 過濾
+}
+
+export interface AreaSceneEntry {
+  scene: Scene;
+  open: boolean; // 依 timeGate + 目前時鐘判定是否開放進入
+}
+
+export interface AreaView {
+  area: Area;
+  scenes: AreaSceneEntry[];
+}
+
+export interface WorldMapView {
+  unlockedRegions: WorldRegion[];
+}
+
+export type PlayNode =
+  | { kind: "dialogue"; speaker: string; text: string }
+  | { kind: "choice"; prompt: string; options: { index: number; label: string }[] }
+  | { kind: "checkResult"; stat: CaptainStat; difficulty: number; playerValue: number; success: boolean }
+  | { kind: "end" };
+
+interface ActiveEvent {
+  event: GameEvent;
+  nodeId: string;
+}
+
+/**
+ * 事件抽選：從熱點事件池中，過濾出前置條件成立、且未被一次性/冷卻擋掉的事件，
+ * 依權重加權隨機抽一個。回傳 null 代表這個熱點暫時沒有可觸發的事件。
+ */
+export function pickEligibleEvent(
+  hotspot: Hotspot,
+  content: ContentPack,
+  state: SaveState,
+  rng: () => number,
+): GameEvent | null {
+  const candidates = hotspot.eventPool
+    .map((id) => content.events[id])
+    .filter((ev): ev is GameEvent => !!ev)
+    .filter((ev) => {
+      // weight <= 0 事件永遠不進隨機池——只能靠 startEvent() 直接觸發（例如
+      // 主線關鍵事件由任務系統直接指定，而非讓場景隨機抽到）。
+      if (ev.weight <= 0) return false;
+      const history = state.eventHistory[ev.id];
+      if (ev.once && history && history.count > 0) return false;
+      if (ev.cooldownDays && history && state.clock.day - history.lastAtDay < ev.cooldownDays) return false;
+      return evaluateCondition(ev.precondition, state);
+    });
+  if (candidates.length === 0) return null;
+
+  const totalWeight = candidates.reduce((acc, ev) => acc + ev.weight, 0);
+  let roll = rng() * totalWeight;
+  for (const ev of candidates) {
+    roll -= ev.weight;
+    if (roll <= 0) return ev;
+  }
+  return candidates[candidates.length - 1];
+}
+
+function resolveSkillCheck(
+  node: Extract<EventNode, { kind: "skillCheck" }>,
+  state: SaveState,
+  rng: () => number,
+): { success: boolean; playerValue: number } {
+  const base = state.captainStats[node.stat];
+  const modifier = (node.modifierFrom ?? []).reduce(
+    (acc, m) => acc + (evaluateCondition(m.cond, state) ? m.bonus : 0),
+    0,
+  );
+  const spread = Math.floor(rng() * 21) - 10; // -10..+10
+  const roll = base + modifier + spread;
+  return { success: roll >= node.difficulty, playerValue: base + modifier };
+}
+
+/**
+ * RPG 引擎（docs/29）。純框架：對內容一無所知，只認 ContentPack 的資料結構。
+ * 場景瀏覽（getSceneView）與事件推進（interact/continue/choose）是唯二的
+ * 玩家互動入口；所有狀態改變只透過 applyEffect 發生，方便測試與存讀檔。
+ */
+export class RpgEngine {
+  private _state: SaveState;
+  private active: ActiveEvent | null = null;
+  private readonly rng: () => number;
+
+  constructor(
+    private readonly content: ContentPack,
+    initialState: SaveState,
+    rng: () => number = Math.random,
+  ) {
+    this._state = initialState;
+    this.rng = rng;
+  }
+
+  get state(): SaveState {
+    return this._state;
+  }
+
+  getWorldMapView(): WorldMapView {
+    return {
+      unlockedRegions: this._state.unlocked.regions
+        .map((id) => this.content.regions[id])
+        .filter((r): r is WorldRegion => !!r),
+    };
+  }
+
+  getAreaView(areaId: string): AreaView {
+    const area = this.content.areas[areaId];
+    if (!area) throw new Error(`unknown area: ${areaId}`);
+    const scenes = area.scenes
+      .map((id) => this.content.scenes[id])
+      .filter((s): s is Scene => !!s)
+      .map((scene) => ({ scene, open: this.isSceneOpen(scene) }));
+    return { area, scenes };
+  }
+
+  /** 場景是否依 timeGate 對目前時鐘開放（無 timeGate 視為永遠開放）。 */
+  isSceneOpen(scene: Scene): boolean {
+    if (!scene.timeGate) return true;
+    return evaluateCondition({ kind: "time", window: scene.timeGate }, this._state);
+  }
+
+  /** 玩家主動「等待」推進時間（不觸發任何事件），例如等某場景開門。 */
+  advanceTime(steps: number): void {
+    this._state = applyEffect({ advanceTime: steps }, this._state);
+  }
+
+  getSceneView(sceneId: string): SceneView {
+    const scene = this.content.scenes[sceneId];
+    if (!scene) throw new Error(`unknown scene: ${sceneId}`);
+    const hotspots = scene.hotspots.filter(
+      (h) => !h.visibleIf || evaluateCondition(h.visibleIf, this._state),
+    );
+    return { scene, hotspots };
+  }
+
+  /** 玩家移動到某個場景（僅記錄當前位置，不觸發事件）。 */
+  travelTo(sceneId: string): void {
+    if (!this._state.unlocked.scenes.includes(sceneId)) {
+      throw new Error(`scene not unlocked: ${sceneId}`);
+    }
+    const scene = this.content.scenes[sceneId];
+    if (!scene) throw new Error(`unknown scene: ${sceneId}`);
+    if (!this.isSceneOpen(scene)) {
+      throw new Error(`scene not open at this hour: ${sceneId}`);
+    }
+    this._state = { ...this._state, currentSceneId: sceneId };
+  }
+
+  /** 點擊熱點：抽一個符合條件的事件並開始播放。沒有可觸發事件時回傳 null。 */
+  interact(hotspotId: string): PlayNode | null {
+    const scene = this.content.scenes[this._state.currentSceneId];
+    const hotspot = scene?.hotspots.find((h) => h.id === hotspotId);
+    if (!hotspot) throw new Error(`unknown hotspot: ${hotspotId}`);
+
+    const event = pickEligibleEvent(hotspot, this.content, this._state, this.rng);
+    if (!event) return null;
+    return this.startEvent(event.id);
+  }
+
+  startEvent(eventId: string): PlayNode {
+    const event = this.content.events[eventId];
+    if (!event) throw new Error(`unknown event: ${eventId}`);
+    this.active = { event, nodeId: event.entryNodeId };
+    return this.resolveToPause();
+  }
+
+  /** 推進對話/判定結果節點（不需要玩家選擇的節點）到下一個需要暫停的節點。 */
+  continue(): PlayNode {
+    if (!this.active) throw new Error("no active event");
+    const node = this.currentNode();
+    if (node.kind !== "dialogue" && node.kind !== "skillCheck") {
+      throw new Error(`continue() called on non-continuable node: ${node.kind}`);
+    }
+    if (node.kind === "dialogue") {
+      this.active.nodeId = node.goto;
+      return this.resolveToPause();
+    }
+    // skillCheck 節點在 resolveToPause 已經算完結果並暫停在 checkResult 上，
+    // continue() 這裡是玩家看完判定結果後，才真正走向 onSuccess/onFailure。
+    const resolved = this.lastCheckResolution;
+    if (!resolved) throw new Error("skill check not resolved");
+    this.active.nodeId = resolved.success ? node.onSuccess : node.onFailure;
+    this.lastCheckResolution = undefined;
+    return this.resolveToPause();
+  }
+
+  choose(optionIndex: number): PlayNode {
+    if (!this.active) throw new Error("no active event");
+    const node = this.currentNode();
+    if (node.kind !== "choice") throw new Error("choose() called on non-choice node");
+    const visible = node.options.filter((o) => !o.visibleIf || evaluateCondition(o.visibleIf, this._state));
+    const option = visible[optionIndex];
+    if (!option) throw new Error(`invalid option index: ${optionIndex}`);
+    this.active.nodeId = option.goto;
+    return this.resolveToPause();
+  }
+
+  private lastCheckResolution: { success: boolean } | undefined;
+
+  private currentNode(): EventNode {
+    if (!this.active) throw new Error("no active event");
+    const node = this.active.event.nodes.find((n) => n.id === this.active!.nodeId);
+    if (!node) throw new Error(`unknown node: ${this.active.nodeId} in event ${this.active.event.id}`);
+    return node;
+  }
+
+  /** 自動吃掉 effect/goto 節點，直到遇到需要玩家看/選的節點，或事件結束。 */
+  private resolveToPause(): PlayNode {
+    if (!this.active) throw new Error("no active event");
+
+    while (true) {
+      if (this.active.nodeId === "END") {
+        this.finishActiveEvent();
+        return { kind: "end" };
+      }
+
+      const node = this.currentNode();
+      switch (node.kind) {
+        case "dialogue":
+          return { kind: "dialogue", speaker: node.speaker, text: node.text };
+        case "choice": {
+          const visible = node.options.filter(
+            (o) => !o.visibleIf || evaluateCondition(o.visibleIf, this._state),
+          );
+          return {
+            kind: "choice",
+            prompt: node.prompt,
+            options: visible.map((o, index) => ({ index, label: o.label })),
+          };
+        }
+        case "skillCheck": {
+          const result = resolveSkillCheck(node, this._state, this.rng);
+          this.lastCheckResolution = { success: result.success };
+          return {
+            kind: "checkResult",
+            stat: node.stat,
+            difficulty: node.difficulty,
+            playerValue: result.playerValue,
+            success: result.success,
+          };
+        }
+        case "effect":
+          this._state = applyEffect(node.effect, this._state);
+          this.active.nodeId = node.goto;
+          continue;
+        case "goto":
+          this.active.nodeId = node.goto;
+          continue;
+      }
+    }
+  }
+
+  private finishActiveEvent(): void {
+    if (!this.active) return;
+    const id = this.active.event.id;
+    const prev = this._state.eventHistory[id];
+    this._state = {
+      ...this._state,
+      eventHistory: {
+        ...this._state.eventHistory,
+        [id]: { count: (prev?.count ?? 0) + 1, lastAtDay: this._state.clock.day },
+      },
+    };
+    this.active = null;
+  }
+}

--- a/azure-voyage/packages/rpg-engine/src/index.ts
+++ b/azure-voyage/packages/rpg-engine/src/index.ts
@@ -1,0 +1,5 @@
+export * from "./types";
+export * from "./condition";
+export * from "./effect";
+export * from "./engine";
+export * from "./validate";

--- a/azure-voyage/packages/rpg-engine/src/types.ts
+++ b/azure-voyage/packages/rpg-engine/src/types.ts
@@ -1,0 +1,279 @@
+/**
+ * Azure Voyage RPG 引擎核心型別（docs/29）。純框架，不含任何蒼瀾世界的具體
+ * 內容——內容由 @azure-voyage/rpg-content 以這裡定義的型別宣告。
+ */
+
+// ── 提督五維（復用既有沙盒版 M27 概念，用於技能判定）──
+export const CAPTAIN_STATS = ["lead", "nav", "combat", "trade", "lore"] as const;
+export type CaptainStat = (typeof CAPTAIN_STATS)[number];
+
+// ── 時間 ──
+export const GAME_PHASES = ["DAWN", "DAY", "DUSK", "NIGHT"] as const;
+export type GamePhase = (typeof GAME_PHASES)[number];
+
+export const SEASONS = ["SPRING", "SUMMER", "AUTUMN", "WINTER"] as const;
+export type Season = (typeof SEASONS)[number];
+
+export interface GameClock {
+  day: number;
+  phase: GamePhase;
+  season: Season;
+}
+
+export interface TimeWindow {
+  phases?: GamePhase[];
+  seasons?: Season[];
+  minDay?: number;
+  maxDay?: number;
+}
+
+// ── 條件語言：所有系統共用的唯一判定式 ──
+export type Condition =
+  | { kind: "flag"; flag: string; value: boolean }
+  | { kind: "worldState"; path: string; op: ">=" | "<=" | "=="; value: number | string }
+  | { kind: "affinity"; npc: string; op: ">="; value: number }
+  | { kind: "stat"; stat: CaptainStat; op: ">="; value: number }
+  | { kind: "reputation"; area: string; op: ">="; value: number }
+  | { kind: "time"; window: TimeWindow }
+  | { kind: "exploration"; area: string; op: ">="; value: number }
+  | { kind: "eventCompleted"; event: string }
+  | { kind: "and"; all: Condition[] }
+  | { kind: "or"; any: Condition[] }
+  | { kind: "not"; cond: Condition }
+  | { kind: "always" };
+
+// ── 後果語言：事件如何改變世界 ──
+export interface Effect {
+  setFlags?: string[];
+  worldState?: { path: string; delta?: number; set?: number | string }[];
+  affinity?: { npc: string; delta: number }[];
+  reputation?: { area: string; delta: number }[];
+  unlock?: { regions?: string[]; areas?: string[]; scenes?: string[] };
+  advanceTime?: number; // 推進幾個「時段」（DAWN→DAY→DUSK→NIGHT→隔天 DAWN）
+  giveItem?: string[];
+}
+
+// ── 世界狀態：少數幾條連續/多值軸，取代大量離散 Flag ──
+export interface WorldState {
+  crimsonThreat: number; // 0–100
+  guildOrder: Record<string, number>;
+  seaOmen: "CALM" | "STIRRING" | "AWAKENED";
+  regionCorruption: Record<string, number>;
+  truthProgress: number; // 0–5
+  playerStance: "NONE" | "TRADER" | "AVENGER" | "SEEKER";
+}
+
+export function initialWorldState(): WorldState {
+  return {
+    crimsonThreat: 0,
+    guildOrder: {},
+    seaOmen: "CALM",
+    regionCorruption: {},
+    truthProgress: 0,
+    playerStance: "NONE",
+  };
+}
+
+// ── 三層世界架構 ──
+export interface WorldRegion {
+  id: string;
+  name: string;
+  unlockCondition: Condition;
+  areas: string[];
+}
+
+export interface ExplorationMilestone {
+  at: number; // 0-100 門檻
+  reveal: { scenes?: string[]; discoveries?: string[]; events?: string[] };
+}
+
+export interface ExplorationTrack {
+  milestones: ExplorationMilestone[];
+}
+
+export interface Area {
+  id: string;
+  regionId: string;
+  name: string;
+  kind: "PORT" | "WILDERNESS";
+  unlockCondition: Condition;
+  scenes: string[];
+  exploration?: ExplorationTrack;
+}
+
+export interface Hotspot {
+  id: string;
+  label: string;
+  eventPool: string[];
+  visibleIf?: Condition;
+}
+
+export interface Scene {
+  id: string;
+  areaId: string;
+  name: string;
+  hotspots: Hotspot[];
+  timeGate?: TimeWindow;
+}
+
+// ── 事件系統 ──
+export interface DialogueNode {
+  kind: "dialogue";
+  id: string;
+  speaker: string;
+  text: string;
+  goto: string;
+}
+
+export interface ChoiceOption {
+  label: string;
+  visibleIf?: Condition;
+  goto: string;
+}
+
+export interface ChoiceNode {
+  kind: "choice";
+  id: string;
+  prompt: string;
+  options: ChoiceOption[];
+}
+
+export interface SkillCheckNode {
+  kind: "skillCheck";
+  id: string;
+  stat: CaptainStat;
+  difficulty: number;
+  modifierFrom?: { cond: Condition; bonus: number }[];
+  onSuccess: string;
+  onFailure: string;
+}
+
+export interface EffectNode {
+  kind: "effect";
+  id: string;
+  effect: Effect;
+  goto: string;
+}
+
+export interface GotoNode {
+  kind: "goto";
+  id: string;
+  goto: string;
+}
+
+export type EventNode = DialogueNode | ChoiceNode | SkillCheckNode | EffectNode | GotoNode;
+
+export interface GameEvent {
+  id: string;
+  precondition: Condition;
+  weight: number;
+  once: boolean;
+  cooldownDays?: number;
+  entryNodeId: string;
+  nodes: EventNode[];
+}
+
+// ── NPC ──
+export interface AffinityTier {
+  threshold: number;
+  unlockEvents: string[];
+}
+
+export interface ScheduleEntry {
+  when: Condition;
+  scene: string;
+}
+
+export interface Npc {
+  id: string;
+  name: string;
+  portrait: string;
+  homeScene: string;
+  schedule?: ScheduleEntry[];
+  affinityTiers?: AffinityTier[];
+}
+
+// ── 任務 ──
+export interface Objective {
+  id: string;
+  description: string;
+  completeWhen: Condition;
+}
+
+export interface Quest {
+  id: string;
+  kind: "MAIN" | "SIDE" | "HIDDEN" | "TIMED";
+  title: string;
+  giver?: string;
+  precondition: Condition;
+  objectives: Objective[];
+  deadline?: { atDay: number; onExpire: Effect };
+  rewards: Effect;
+}
+
+// ── 內容包：rpg-content 注入給引擎的完整宣告式資料 ──
+export interface ContentPack {
+  regions: Record<string, WorldRegion>;
+  areas: Record<string, Area>;
+  scenes: Record<string, Scene>;
+  events: Record<string, GameEvent>;
+  npcs: Record<string, Npc>;
+  quests: Record<string, Quest>;
+  startSceneId: string;
+}
+
+// ── 存檔 ──
+export interface EventHistoryEntry {
+  count: number;
+  lastAtDay: number;
+}
+
+export interface SaveState {
+  clock: GameClock;
+  flags: string[];
+  worldState: WorldState;
+  affinity: Record<string, number>;
+  reputation: Record<string, number>;
+  exploration: Record<string, number>;
+  captainStats: Record<CaptainStat, number>;
+  eventHistory: Record<string, EventHistoryEntry>;
+  questProgress: Record<string, { active: boolean; completed: boolean; objectivesDone: string[] }>;
+  unlocked: { regions: string[]; areas: string[]; scenes: string[] };
+  inventory: string[];
+  playthrough: number;
+  currentSceneId: string;
+}
+
+export function createInitialSaveState(opts: {
+  startSceneId: string;
+  startAreaId: string;
+  startRegionId: string;
+  captainStats?: Partial<Record<CaptainStat, number>>;
+}): SaveState {
+  return {
+    clock: { day: 1, phase: "DAWN", season: "SPRING" },
+    flags: [],
+    worldState: initialWorldState(),
+    affinity: {},
+    reputation: {},
+    exploration: {},
+    captainStats: {
+      lead: 20,
+      nav: 20,
+      combat: 20,
+      trade: 20,
+      lore: 20,
+      ...opts.captainStats,
+    },
+    eventHistory: {},
+    questProgress: {},
+    unlocked: {
+      regions: [opts.startRegionId],
+      areas: [opts.startAreaId],
+      scenes: [opts.startSceneId],
+    },
+    inventory: [],
+    playthrough: 1,
+    currentSceneId: opts.startSceneId,
+  };
+}

--- a/azure-voyage/packages/rpg-engine/src/validate.ts
+++ b/azure-voyage/packages/rpg-engine/src/validate.ts
@@ -1,0 +1,78 @@
+import type { ContentPack, EventNode } from "./types";
+
+function nodeTargets(node: EventNode): string[] {
+  switch (node.kind) {
+    case "dialogue":
+      return [node.goto];
+    case "choice":
+      return node.options.map((o) => o.goto);
+    case "skillCheck":
+      return [node.onSuccess, node.onFailure];
+    case "effect":
+      return [node.goto];
+    case "goto":
+      return [node.goto];
+  }
+}
+
+/**
+ * 建置期內容檢查（docs/29 §12）：所有 id 引用是否完整、事件節點是否成孤島。
+ * 回傳錯誤訊息陣列；空陣列代表內容包合法。
+ */
+export function validateContent(pack: ContentPack): string[] {
+  const errors: string[] = [];
+
+  if (!pack.scenes[pack.startSceneId]) {
+    errors.push(`startSceneId 指向不存在的場景: ${pack.startSceneId}`);
+  }
+
+  for (const region of Object.values(pack.regions)) {
+    for (const areaId of region.areas) {
+      if (!pack.areas[areaId]) errors.push(`海域 ${region.id} 引用了不存在的 area: ${areaId}`);
+    }
+  }
+
+  for (const area of Object.values(pack.areas)) {
+    if (!pack.regions[area.regionId]) {
+      errors.push(`area ${area.id} 引用了不存在的 region: ${area.regionId}`);
+    }
+    for (const sceneId of area.scenes) {
+      if (!pack.scenes[sceneId]) errors.push(`area ${area.id} 引用了不存在的 scene: ${sceneId}`);
+    }
+  }
+
+  for (const scene of Object.values(pack.scenes)) {
+    if (!pack.areas[scene.areaId]) {
+      errors.push(`scene ${scene.id} 引用了不存在的 area: ${scene.areaId}`);
+    }
+    for (const hotspot of scene.hotspots) {
+      for (const eventId of hotspot.eventPool) {
+        if (!pack.events[eventId]) {
+          errors.push(`scene ${scene.id} 熱點 ${hotspot.id} 引用了不存在的 event: ${eventId}`);
+        }
+      }
+    }
+  }
+
+  for (const event of Object.values(pack.events)) {
+    const nodeIds = new Set(event.nodes.map((n) => n.id));
+    if (!nodeIds.has(event.entryNodeId)) {
+      errors.push(`event ${event.id} 的 entryNodeId 找不到對應節點: ${event.entryNodeId}`);
+    }
+    for (const node of event.nodes) {
+      for (const target of nodeTargets(node)) {
+        if (target !== "END" && !nodeIds.has(target)) {
+          errors.push(`event ${event.id} 節點 ${node.id} 指向不存在的節點: ${target}`);
+        }
+      }
+    }
+  }
+
+  for (const quest of Object.values(pack.quests)) {
+    if (quest.giver && !pack.npcs[quest.giver]) {
+      errors.push(`quest ${quest.id} 引用了不存在的 npc: ${quest.giver}`);
+    }
+  }
+
+  return errors;
+}

--- a/azure-voyage/packages/rpg-engine/tsconfig.json
+++ b/azure-voyage/packages/rpg-engine/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@azure-voyage/tsconfig/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/azure-voyage/pnpm-lock.yaml
+++ b/azure-voyage/pnpm-lock.yaml
@@ -125,6 +125,49 @@ importers:
         specifier: ^5.7.2
         version: 5.9.3
 
+  apps/rpg:
+    dependencies:
+      '@azure-voyage/rpg-content':
+        specifier: workspace:*
+        version: link:../../packages/rpg-content
+      '@azure-voyage/rpg-engine':
+        specifier: workspace:*
+        version: link:../../packages/rpg-engine
+      next:
+        specifier: ^15.1.4
+        version: 15.5.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@azure-voyage/tsconfig':
+        specifier: workspace:*
+        version: link:../../packages/tsconfig
+      '@types/node':
+        specifier: ^22.10.5
+        version: 22.20.0
+      '@types/react':
+        specifier: ^19.0.2
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.0.2
+        version: 19.2.3(@types/react@19.2.17)
+      autoprefixer:
+        specifier: ^10.4.20
+        version: 10.5.2(postcss@8.5.16)
+      postcss:
+        specifier: ^8.4.49
+        version: 8.5.16
+      tailwindcss:
+        specifier: ^3.4.17
+        version: 3.4.19(tsx@4.23.0)
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+
   apps/web:
     dependencies:
       '@azure-voyage/shared':
@@ -173,6 +216,34 @@ importers:
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
+
+  packages/rpg-content:
+    dependencies:
+      '@azure-voyage/rpg-engine':
+        specifier: workspace:*
+        version: link:../rpg-engine
+    devDependencies:
+      '@azure-voyage/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@22.20.0)(terser@5.48.0)
+
+  packages/rpg-engine:
+    devDependencies:
+      '@azure-voyage/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@22.20.0)(terser@5.48.0)
 
   packages/shared:
     dependencies:


### PR DESCRIPTION
## Summary

依 `docs/29`（RPG Framework 設計）的路線圖實作前三個階段（P0/P1/P2），獨立於既有沙盒經營版之外，共用同一個蒼瀾世界觀，**不改動 `apps/web`/`apps/api` 任何程式碼**：

- **`packages/rpg-engine`（P0，純框架）**：`Condition`/`Effect` 統一條件語言、三層世界架構（Region/Area/Scene/Hotspot）、事件引擎（`interact`/`continue`/`choose`）、時段閘門、`validateContent` 建置期檢查。22 個單元測試，過程中抓到並修正兩個真實 bug：
  - `worldState` 路徑解析原本用遞迴 `.split(".")`，會把含點的 record 鍵（如 `"npc.crimson_sails"`）誤拆——改成只切第一刀的兩層路徑。
  - 事件池加權隨機選取時，`weight: 0` 的稀有事件在候選只剩它自己時仍會被抽中——改成候選階段直接濾掉。

- **`packages/rpg-content`（P1+P2，垂直切片內容）**：奧雷利亞 3 場景（港務廳/酒館/市場，各自不同時段開放）+ 佩爾蘭支線場景，9 個事件對映小說（`docs/28`）第一部第一～四、六章，4 個任務宣告沿用 M28 QuestService「用既有可查詢狀態判定」的哲學。4 個測試含完整主線＋支線一輪遊玩（含分支選擇）的確定性驗證。

- **`apps/rpg`（P1，最小可玩前端）**：獨立 Next.js app，純用戶端 + `localStorage` 存檔，世界地圖／港口場景／事件面板／航海日誌四個介面區塊。

## 端對端驗證

本機真實跑起 `apps/rpg` dev server，用 Playwright 完整跑一輪：開場（選對話回應）→ 等到黃昏進酒館招募雙人班底 → 隔天進市場完成第一筆交易 → 緋帆團初現事件（技能判定分支）解鎖世界地圖與佩爾蘭 → 佩爾蘭老漁夫支線完成。過程中發現並補上原本缺漏的「切換港口」世界地圖 UI（原本只做了同港口內場景切換，佩爾蘭解鎖後其實無路可去）。最終航海日誌四項任務（主線三章 + 支線）全數打勾，截圖確認。

## Test plan

- [x] `@azure-voyage/rpg-engine`：22 測試全綠
- [x] `@azure-voyage/rpg-content`：4 測試全綠（含完整劇情分支遊玩）
- [x] `@azure-voyage/rpg`：`tsc --noEmit`、`next build` 全綠
- [x] 新三個套件 ESLint 全綠（`eslint.config.mjs` 補上 `apps/rpg/next-env.d.ts` 忽略規則）
- [x] 既有 `@azure-voyage/api`／`@azure-voyage/web` `tsc --noEmit` 確認不受影響
- [x] 本機真實 dev server + Playwright 端對端跑通完整一輪（見上）

詳見 `docs/30-rpg-p0-p2.md`。

Claude-Session: https://claude.ai/code/session_013kDwmPmYtbENLcfMzDdnNF


---
_Generated by [Claude Code](https://claude.ai/code/session_013kDwmPmYtbENLcfMzDdnNF)_