### PR TITLE
改善 api/web Dockerfile 建置速度：拆分依賴安裝與原始碼複製層

### DIFF
--- a/azure-voyage/apps/api/Dockerfile
+++ b/azure-voyage/apps/api/Dockerfile
@@ -1,12 +1,27 @@
+# syntax=docker/dockerfile:1
 FROM node:22-alpine AS base
 RUN corepack enable
 WORKDIR /repo
 
 FROM base AS build
+# 先只複製套件清單（package.json + lockfile），讓 `pnpm install` 這層只在
+# 依賴真的變動時才失效——原本整包原始碼複製完才 install，改一行程式碼就要
+# 重新解析/下載全部依賴，是這裡最大的建置時間浪費。
 COPY pnpm-workspace.yaml package.json pnpm-lock.yaml .npmrc ./
-COPY packages ./packages
+COPY packages/shared/package.json ./packages/shared/package.json
+COPY packages/tsconfig/package.json ./packages/tsconfig/package.json
+COPY apps/api/package.json ./apps/api/package.json
+RUN --mount=type=cache,id=azure-voyage-pnpm-store,target=/pnpm/store \
+    pnpm install --frozen-lockfile --store-dir=/pnpm/store
+
+# 這層之後才複製原始碼；只有原始碼變動時才會重跑，上面的 install 層仍能命中
+# 快取（同一台 Docker host 上，cache mount 讓 pnpm store 也跨 build 保留，
+# 就算 lockfile 真的變了也不必整批重新下載——web 端 Dockerfile 用同一個
+# cache id，`docker compose --profile full up --build` 同時建置兩個
+# image 時，共用依賴只需下載一次）。
+COPY packages/shared ./packages/shared
+COPY packages/tsconfig ./packages/tsconfig
 COPY apps/api ./apps/api
-RUN pnpm install --frozen-lockfile
 RUN pnpm --filter @azure-voyage/shared build && pnpm --filter @azure-voyage/api build
 RUN pnpm --filter @azure-voyage/api --prod deploy /out
 RUN cd /out && npx prisma generate

--- a/azure-voyage/apps/web/Dockerfile
+++ b/azure-voyage/apps/web/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM node:22-alpine AS base
 RUN corepack enable
 WORKDIR /repo
@@ -5,10 +6,23 @@ WORKDIR /repo
 FROM base AS build
 ARG NEXT_PUBLIC_API_URL=http://localhost:3001
 ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
+# 先只複製套件清單（package.json + lockfile），讓 `pnpm install` 這層只在
+# 依賴真的變動時才失效——原本整包原始碼複製完才 install，改一行程式碼就要
+# 重新解析/下載全部依賴，是這裡最大的建置時間浪費（web 的依賴比 api 重，
+# 這一步原本要 80 秒以上）。
 COPY pnpm-workspace.yaml package.json pnpm-lock.yaml .npmrc ./
-COPY packages ./packages
+COPY packages/shared/package.json ./packages/shared/package.json
+COPY packages/tsconfig/package.json ./packages/tsconfig/package.json
+COPY apps/web/package.json ./apps/web/package.json
+RUN --mount=type=cache,id=azure-voyage-pnpm-store,target=/pnpm/store \
+    pnpm install --frozen-lockfile --store-dir=/pnpm/store
+
+# 這層之後才複製原始碼；只有原始碼變動時才會重跑，上面的 install 層仍能命中
+# 快取（cache mount 讓 pnpm store 也跨 build 保留，就算 lockfile 真的變了
+# 也不必整批重新下載）。
+COPY packages/shared ./packages/shared
+COPY packages/tsconfig ./packages/tsconfig
 COPY apps/web ./apps/web
-RUN pnpm install --frozen-lockfile
 RUN pnpm --filter @azure-voyage/shared build && pnpm --filter @azure-voyage/web build
 
 FROM node:22-alpine


### PR DESCRIPTION
## Summary

根因：`apps/api/Dockerfile`／`apps/web/Dockerfile` 原本先把整包原始碼複製進去才跑 `pnpm install`，導致改一行程式碼就讓 Docker layer cache 從那個 COPY 開始整層失效，逼得每次都重新解析/下載全部依賴（使用者實測 api 27.5s／web 81.8s）。

- **拆分 COPY 順序**：先只複製套件清單（各 `package.json` + lockfile），跑 `pnpm install`；原始碼另外在下一段才複製。只要依賴沒變，install 層就能持續命中快取，不受原始碼變動影響。
- **BuildKit cache mount**：`RUN --mount=type=cache` 讓 pnpm store 跨 build 保留在 Docker host 上，就算 lockfile 真的變了，已下載過的套件也不用重新拉。api/web 共用同一個 cache id，`docker compose --profile full up --build` 一起建置兩個 image 時，共同依賴只需下載一次。
- 加 `# syntax=docker/dockerfile:1` 開頭指令（`RUN --mount` 需要它）。

行為不變：最終產物、CMD、EXPOSE、prisma 流程都沒有動，純粹是 COPY／RUN 順序重排 + 快取設定。

## Test plan

- [x] 仔細覆核 Dockerfile 語法與 COPY 路徑（context 沿用 `docker-compose.yml` 既有的 `context: .`，路徑與原本一致）
- [ ] ⚠️ 本機沙盒環境的網路政策擋掉了 Docker Hub／CloudFront 的 registry 存取（`production.cloudfront.docker.com` 回傳 403 policy denial），沒辦法在這裡實際執行 `docker build` 驗證——請在能連外的機器上跑 `docker compose --profile full up --build` 確認效果（第一次跑會建立快取，第二次起改程式碼重跑應該明顯變快）

Claude-Session: https://claude.ai/code/session_013kDwmPmYtbENLcfMzDdnNF


---
_Generated by [Claude Code](https://claude.ai/code/session_013kDwmPmYtbENLcfMzDdnNF)_