### PR TITLE
新增 azure-voyage-rpg 的 Docker 支援

### DIFF
--- a/azure-voyage-rpg/.dockerignore
+++ b/azure-voyage-rpg/.dockerignore
@@ -1,0 +1,9 @@
+**/node_modules
+**/.next
+**/dist
+**/.turbo
+.git
+.env
+.env.test
+docs
+*.md

--- a/azure-voyage-rpg/README.md
+++ b/azure-voyage-rpg/README.md
@@ -30,3 +30,14 @@ pnpm typecheck
 pnpm test
 pnpm build
 ```
+
+## 用 Docker 一鍵試玩
+
+純前端原型，不需要資料庫/佇列，存檔在瀏覽器 localStorage：
+
+```bash
+docker compose up --build
+```
+
+等 `web` 印出 `Ready` 後，打開 http://localhost:3100 即可遊玩。想清掉容器就
+`docker compose down`（沒有掛 volume，不會留下任何資料）。

--- a/azure-voyage-rpg/apps/web/Dockerfile
+++ b/azure-voyage-rpg/apps/web/Dockerfile
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1
+FROM node:22-alpine AS base
+RUN corepack enable
+WORKDIR /repo
+
+FROM base AS build
+# 先只複製套件清單（package.json + lockfile），讓 `pnpm install` 這層只在
+# 依賴真的變動時才失效，原始碼變動不會逼它重新解析/下載全部依賴。
+COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
+COPY packages/engine/package.json ./packages/engine/package.json
+COPY packages/content/package.json ./packages/content/package.json
+COPY packages/tsconfig/package.json ./packages/tsconfig/package.json
+COPY apps/web/package.json ./apps/web/package.json
+RUN --mount=type=cache,id=azure-voyage-rpg-pnpm-store,target=/pnpm/store \
+    pnpm install --frozen-lockfile --store-dir=/pnpm/store
+
+# 這層之後才複製原始碼；只有原始碼變動時才會重跑，上面的 install 層仍能
+# 命中快取（cache mount 讓 pnpm store 也跨 build 保留在 Docker host 上）。
+COPY packages/engine ./packages/engine
+COPY packages/content ./packages/content
+COPY packages/tsconfig ./packages/tsconfig
+COPY apps/web ./apps/web
+RUN pnpm --filter @azure-voyage-rpg/engine build \
+ && pnpm --filter @azure-voyage-rpg/content build \
+ && pnpm --filter @azure-voyage-rpg/web build
+
+FROM node:22-alpine
+RUN corepack enable
+WORKDIR /repo
+COPY --from=build /repo .
+EXPOSE 3100
+CMD ["pnpm", "--filter", "@azure-voyage-rpg/web", "start"]

--- a/azure-voyage-rpg/docker-compose.yml
+++ b/azure-voyage-rpg/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  # 純前端原型：不需要資料庫/佇列，localStorage 存檔。單一 image 就能玩。
+  web:
+    build:
+      context: .
+      dockerfile: apps/web/Dockerfile
+    ports:
+      - "3100:3100"


### PR DESCRIPTION
## Summary

補上先前搬遷 `azure-voyage-rpg` 為獨立頂層專案時漏掉的部分——它是純前端原型（localStorage 存檔，不需要資料庫/佇列），加一份最小的 `Dockerfile` + `docker-compose.yml` 就能一鍵試玩，不需要另外裝 Node/pnpm。

- `apps/web/Dockerfile`：直接套用剛在 `azure-voyage/apps/{api,web}` 驗證過的教訓——COPY 拆成「先套件清單、後原始碼」兩段，讓 `pnpm install` 這層只在依賴真的變動時才失效；加 BuildKit cache mount 讓 pnpm store 跨 build 保留。
- `docker-compose.yml`：單一 `web` service，對外 port 3100。
- `.dockerignore`：比照 `azure-voyage` 既有寫法。
- `README.md`：補上「用 Docker 一鍵試玩」段落。

## Test plan

- [x] 仔細覆核 Dockerfile 語法與 COPY 路徑（context 對照 `docker-compose.yml` 的 `context: .`）
- [ ] ⚠️ 本機沙盒環境的網路政策擋掉了 Docker Hub 的 registry 存取，沒辦法在這裡實際執行 `docker build` 驗證——請在能連外的機器上跑 `docker compose up --build` 確認 http://localhost:3100 能正常玩

Claude-Session: https://claude.ai/code/session_013kDwmPmYtbENLcfMzDdnNF


---
_Generated by [Claude Code](https://claude.ai/code/session_013kDwmPmYtbENLcfMzDdnNF)_