### PR TITLE
修復 RPG 劇情卡關：加上引路提示與第一部尾聲

### DIFF
--- a/azure-voyage-rpg/apps/web/src/app/globals.css
+++ b/azure-voyage-rpg/apps/web/src/app/globals.css
@@ -486,6 +486,13 @@ body {
   @apply text-sm font-medium;
 }
 
+.scene-stage-wait {
+  position: absolute;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  z-index: 3;
+}
+
 .scene-stage-closed {
   position: absolute;
   left: 1.5rem;
@@ -736,6 +743,10 @@ body {
 
 .scene-nav-buttons {
   @apply flex flex-wrap gap-2;
+}
+
+.guidance-banner {
+  @apply space-y-1 border-gold/40 bg-gold/5;
 }
 
 .route-map-panel {

--- a/azure-voyage-rpg/apps/web/src/game/GameClient.tsx
+++ b/azure-voyage-rpg/apps/web/src/game/GameClient.tsx
@@ -286,6 +286,16 @@ export function GameClient() {
     ],
     [scene.visual?.overlay?.category, scene.visual?.overlay?.id, state.clock.phase],
   );
+  // 目前該做什麼：第一條「已開啟、未完成」的主線目標——常駐顯示，玩家不必開
+  // 日誌就知道下一步往哪走（探索型 RPG 最怕的就是玩家不知道觸發點在哪）。
+  const currentGuidance = useMemo(() => {
+    for (const { quest, objectives } of questSummaries) {
+      if (quest.kind !== "MAIN") continue;
+      const next = objectives.find((o) => !o.done);
+      if (next) return { title: quest.title, objective: next.objective };
+    }
+    return null;
+  }, [questSummaries]);
 
   return (
     <div className="mx-auto max-w-7xl space-y-4 px-4 py-6 md:px-6">
@@ -317,6 +327,16 @@ export function GameClient() {
 
       <div className="game-layout">
         <main className="space-y-4">
+          {currentGuidance && (
+            <section className="panel guidance-banner">
+              <p className="text-xs text-foam/60">目前主線・{currentGuidance.title}</p>
+              <p className="text-sm text-foam/90">◆ {currentGuidance.objective.description}</p>
+              {currentGuidance.objective.hint && (
+                <p className="mt-1 text-xs text-gold/80">↳ {currentGuidance.objective.hint}</p>
+              )}
+            </section>
+          )}
+
           {state.unlocked.areas.length > 0 && (
             <section className="panel route-map-panel">
               <div className="route-map-header">
@@ -583,9 +603,14 @@ export function GameClient() {
                     [{quest.kind === "MAIN" ? "主線" : quest.kind === "SIDE" ? "支線" : quest.kind}] {quest.title}
                   </p>
                   {objectives.map(({ objective, done }) => (
-                    <p key={objective.id} className={`text-xs ${done ? "text-foam/50 line-through" : "text-foam/90"}`}>
-                      {done ? "✓" : "□"} {objective.description}
-                    </p>
+                    <div key={objective.id} className="space-y-0.5">
+                      <p className={`text-xs ${done ? "text-foam/50 line-through" : "text-foam/90"}`}>
+                        {done ? "✓" : "□"} {objective.description}
+                      </p>
+                      {!done && objective.hint && (
+                        <p className="pl-4 text-[11px] text-gold/70">↳ {objective.hint}</p>
+                      )}
+                    </div>
                   ))}
                 </div>
               ))}

--- a/azure-voyage-rpg/apps/web/src/game/SceneStage.tsx
+++ b/azure-voyage-rpg/apps/web/src/game/SceneStage.tsx
@@ -160,26 +160,35 @@ export function SceneStage({
         )}
 
         {sceneOpen ? (
-          <div className="scene-stage-hotspots">
-            {hotspots.map((hotspot, index) => {
-              const position = hotspot.position ?? {
-                x: 24 + index * 26,
-                y: 70 - (index % 2) * 18,
-              };
-              return (
-                <button
-                  key={hotspot.id}
-                  className="scene-hotspot"
-                  style={{ left: `${position.x}%`, top: `${position.y}%` }}
-                  onClick={() => onInteract(hotspot.id)}
-                  disabled={!!activeNode}
-                >
-                  <span className="scene-hotspot-ping" />
-                  <span className="scene-hotspot-label">{hotspot.label}</span>
-                </button>
-              );
-            })}
-          </div>
+          <>
+            <div className="scene-stage-hotspots">
+              {hotspots.map((hotspot, index) => {
+                const position = hotspot.position ?? {
+                  x: 24 + index * 26,
+                  y: 70 - (index % 2) * 18,
+                };
+                return (
+                  <button
+                    key={hotspot.id}
+                    className="scene-hotspot"
+                    style={{ left: `${position.x}%`, top: `${position.y}%` }}
+                    onClick={() => onInteract(hotspot.id)}
+                    disabled={!!activeNode}
+                  >
+                    <span className="scene-hotspot-ping" />
+                    <span className="scene-hotspot-label">{hotspot.label}</span>
+                  </button>
+                );
+              })}
+            </div>
+            {/* 等待鍵在場景開放時也要能按——否則玩家會卡在「所有可去的場景都開著、
+                但需要推進到別的時段才能觸發下一步」的死結（例如黃昏想去白晝的市場）。 */}
+            <div className="scene-stage-wait">
+              <button className="btn-ghost" onClick={onWait} disabled={!!activeNode}>
+                等待一段時間（推進時段）
+              </button>
+            </div>
+          </>
         ) : (
           <div className="scene-stage-closed">
             <p>

--- a/azure-voyage-rpg/packages/content/src/content.test.ts
+++ b/azure-voyage-rpg/packages/content/src/content.test.ts
@@ -84,6 +84,14 @@ describe("main quest chain playthrough (favorable rng)", () => {
     expect(engine.state.unlocked.areas).toContain("area.perlan");
     expect(engine.state.unlocked.scenes).toContain("scene.perlan.docks");
 
+    // ── 序章尾聲：回港務廳向馬瑟斯覆命（此時是黃昏，港務廳仍開門）──
+    engine.travelTo("scene.aurelia.harbor_office");
+    node = engine.interact("hotspot.harbor_office.desk"); // 開場 once 已完成，改觸發 part_one_end
+    expect(node?.kind).toBe("dialogue");
+    node = drain(engine);
+    expect(node.kind).toBe("end");
+    expect(engine.state.flags).toContain("flag.part_one_complete");
+
     // ── 佩爾蘭支線：老漁夫圖克 ──
     engine.travelTo("scene.perlan.docks");
     node = engine.interact("hotspot.perlan.old_fisherman"); // 只有 meet_tuk 符合條件
@@ -105,10 +113,28 @@ describe("main quest chain playthrough (favorable rng)", () => {
     expect(engine.state.reputation["area.perlan"]).toBe(10);
 
     // ── 主線任務目標此刻應全數判定為完成 ──
-    for (const questId of ["quest.ch1_first_trade", "quest.ch2_crew", "quest.ch3_first_battle", "quest.side_perlan"]) {
+    for (const questId of [
+      "quest.ch1_first_trade",
+      "quest.ch2_crew",
+      "quest.ch3_first_battle",
+      "quest.ch4_report_back",
+      "quest.side_perlan",
+    ]) {
       const quest = content.quests[questId];
       for (const objective of quest.objectives) {
         expect(evaluateCondition(objective.completeWhen, engine.state)).toBe(true);
+      }
+    }
+  });
+
+  it("every active MAIN quest always has a discoverable next step (no dead-ends)", () => {
+    // 反卡關保證：主線每一個「已開啟、未完成」的目標都必須帶 hint，且 hint 指向
+    // 的觸發事件在內容包裡真的存在（靠 validateContent 保證引用完整）。這裡確保
+    // 每條主線 objective 都寫了 hint，避免日後新增章節忘了給引路提示又讓玩家卡死。
+    for (const quest of Object.values(content.quests)) {
+      if (quest.kind !== "MAIN") continue;
+      for (const objective of quest.objectives) {
+        expect(objective.hint, `${quest.id}/${objective.id} 缺少 hint`).toBeTruthy();
       }
     }
   });

--- a/azure-voyage-rpg/packages/content/src/events/opening.ts
+++ b/azure-voyage-rpg/packages/content/src/events/opening.ts
@@ -85,4 +85,48 @@ export const OPENING_EVENTS: Record<string, GameEvent> = {
       },
     ],
   },
+  // 第一部尾聲（docs/28 第一部收束）：頂住緋帆團後回港務廳向馬瑟斯覆命。
+  // 同時清楚告訴玩家「目前的原型內容到這裡」，避免劇情突然停住讓人以為卡關。
+  "event.harbor_office.part_one_end": {
+    id: "event.harbor_office.part_one_end",
+    precondition: {
+      kind: "and",
+      all: [
+        { kind: "flag", flag: "flag.first_battle_done", value: true },
+        { kind: "not", cond: { kind: "flag", flag: "flag.part_one_complete", value: true } },
+      ],
+    },
+    weight: 200, // 蓋過同熱點的開場事件（開場 once 已完成，這裡保險起見給高權重）
+    once: true,
+    entryNodeId: "n1",
+    nodes: [
+      {
+        kind: "dialogue",
+        id: "n1",
+        speaker: "馬瑟斯·凡登霍夫",
+        text: "「頂住緋帆團一次了？」老人放下手裡的帳冊，難得地正眼看了你很久。「當年拿著半張圖來的那個年輕人，總算活過了第一個風暴季。」",
+        goto: "n2",
+      },
+      {
+        kind: "dialogue",
+        id: "n2",
+        speaker: "馬瑟斯",
+        text: "「但這只是開始。緋帆團不會善罷甘休，鐵崖、絹風、子午之海……你父親那半張圖指向的地方，還遠得很。」他把印信推回給你，「去吧。晨汐商會的名字，才剛開始有人記得。」",
+        goto: "n3",
+      },
+      {
+        kind: "effect",
+        id: "n3",
+        effect: { setFlags: ["flag.part_one_complete"] },
+        goto: "n_ooc",
+      },
+      {
+        kind: "dialogue",
+        id: "n_ooc",
+        speaker: "【第一部・完】",
+        text: "感謝遊玩《蒼瀾航路：晨汐紀事》的原型。第一部「初出茅廬」到此告一段落——後續章節（跨海域擴張、緋帆團的真正面目、暮色洋盡頭的沉船真相）正在開發中。你隨時可以繼續在琥珀灣走動、探索佩爾蘭，或用右上角「重新開始」再走一遍不同的選擇。",
+        goto: "END",
+      },
+    ],
+  },
 };

--- a/azure-voyage-rpg/packages/content/src/quests.ts
+++ b/azure-voyage-rpg/packages/content/src/quests.ts
@@ -6,6 +6,10 @@ import type { Quest } from "@azure-voyage-rpg/engine";
  * 不需要另外的計數器。獎勵已經在完成任務的事件 effect 節點裡直接發放
  * （見 events/*.ts），這裡的 rewards 欄位純粹是任務面板顯示用的文案來源，
  * 引擎不會自動套用它——避免重複發放。
+ *
+ * 每個 objective 都帶 hint（引路提示），明確告訴玩家「去哪、什麼時候」才能
+ * 推進——這是探索型 RPG 最容易卡關的地方（觸發點藏在特定場景 + 特定時段 +
+ * 特定前置條件裡，玩家找不到就以為遊戲壞了）。
  */
 export const QUESTS: Record<string, Quest> = {
   "quest.ch1_first_trade": {
@@ -18,6 +22,7 @@ export const QUESTS: Record<string, Quest> = {
       {
         id: "obj.first_trade",
         description: "在中央市場完成第一筆交易",
+        hint: "中央市場只在白晝營業，點「貨攤」談生意。",
         completeWhen: { kind: "flag", flag: "flag.first_trade_done", value: true },
       },
     ],
@@ -33,6 +38,7 @@ export const QUESTS: Record<string, Quest> = {
       {
         id: "obj.recruit_crew",
         description: "在錨與星酒館招募滿 2 名班底",
+        hint: "錨與星酒館黃昏後才開門，到「吧檯」找人（先招舵手，再招帳房）。時間不對就用「等待一段時間」。",
         completeWhen: { kind: "flag", flag: "flag.crew_assembled", value: true },
       },
     ],
@@ -48,7 +54,24 @@ export const QUESTS: Record<string, Quest> = {
       {
         id: "obj.first_battle",
         description: "頂住緋帆團的第一次試探",
+        hint: "白晝回到中央市場，班底到齊後那裡會多出「碼頭瞭望」——去查看緋帆團的動向。",
         completeWhen: { kind: "flag", flag: "flag.first_battle_done", value: true },
+      },
+    ],
+    rewards: {},
+  },
+  "quest.ch4_report_back": {
+    id: "quest.ch4_report_back",
+    kind: "MAIN",
+    title: "序章・尾聲",
+    giver: "npc.mathers",
+    precondition: { kind: "flag", flag: "flag.first_battle_done", value: true },
+    objectives: [
+      {
+        id: "obj.report_back",
+        description: "回港務廳向馬瑟斯覆命",
+        hint: "港務廳白晝／黃昏開門，點「長桌前的馬瑟斯」。",
+        completeWhen: { kind: "flag", flag: "flag.part_one_complete", value: true },
       },
     ],
     rewards: {},
@@ -63,6 +86,7 @@ export const QUESTS: Record<string, Quest> = {
       {
         id: "obj.reopen_saltfield",
         description: "再訪佩爾蘭，看看鹽田重開的結果",
+        hint: "頂住緋帆團後，用上方「世界地圖」切到佩爾蘭，再點「老漁夫圖克」。",
         completeWhen: { kind: "flag", flag: "flag.perlan_quest_completed", value: true },
       },
     ],

--- a/azure-voyage-rpg/packages/content/src/scenes/aurelia.ts
+++ b/azure-voyage-rpg/packages/content/src/scenes/aurelia.ts
@@ -26,7 +26,7 @@ export const AURELIA_SCENES: Record<string, Scene> = {
       {
         id: "hotspot.harbor_office.desk",
         label: "長桌前的馬瑟斯",
-        eventPool: ["event.opening"],
+        eventPool: ["event.opening", "event.harbor_office.part_one_end"],
         position: { x: 31, y: 66 },
       },
       {

--- a/azure-voyage-rpg/packages/engine/src/types.ts
+++ b/azure-voyage-rpg/packages/engine/src/types.ts
@@ -272,6 +272,8 @@ export interface Npc {
 export interface Objective {
   id: string;
   description: string;
+  /** 引路提示：告訴玩家「去哪、什麼時候」才能推進，避免探索型 RPG 卡在找不到觸發點。 */
+  hint?: string;
   completeWhen: Condition;
 }
 


### PR DESCRIPTION
## 問題

使用者回報「玩到一半卡住，沒辦法推動劇情」。實際跑起來排查後確認**不是硬鎖**，而是探索型 RPG 典型的「找不到觸發點」卡關：

- 玩家在酒館招募完班底（主線 ch2「組建班底」完成）後，下一步「頂住緋帆團」的觸發點藏在三重條件疊加之下——**中央市場 + 白晝營業 + 班底到齊後才出現的「碼頭瞭望」熱點**。玩家招募完通常正站在黃昏的酒館裡，完全看不出要往哪走。
- 就算走完全部內容，劇情也只是靜靜停住，沒有任何「內容到此為止」的訊號，同樣像壞掉。

## 修法（把「引路」變成框架一等公民）

- **engine**：`Objective` 新增選填 `hint` 欄位。
- **content**：四條主線 + 佩爾蘭支線的每個 objective 都補上「去哪、什麼時候、點哪個熱點」的具體 hint。
- **content**：新增「序章・尾聲」事件——頂住緋帆團後回港務廳向馬瑟斯覆命，一段收束對話明確告訴玩家「第一部到此，後續章節（跨海域擴張、緋帆團真面目、暮色洋沉船真相）開發中」，並新增對應的 ch4 主線任務，給玩家明確的最後一步。
- **web**：常駐顯示「目前主線」的下一個未完成目標 + hint（不必開日誌就看得到下一步）；日誌內未完成目標也一併顯示 hint。

## Test plan

- [x] content 新增反卡關守衛測試「主線每個 objective 都必須有 hint」
- [x] 尾聲納入完整遊玩測試 — `@azure-voyage-rpg/content` 5 個測試全綠、`@azure-voyage-rpg/engine` 22 個全綠
- [x] `tsc --noEmit` + `next build` + 根目錄 `eslint .` 全綠
- [x] 本機真實 dev server + Playwright 從開場玩到第一部尾聲：逐步截圖確認每一步都有常駐引路、以前的卡點（招募完班底站在酒館）現在有明確提示、尾聲「第一部・完」收束頁正確顯示給玩家

Claude-Session: https://claude.ai/code/session_013kDwmPmYtbENLcfMzDdnNF


---
_Generated by [Claude Code](https://claude.ai/code/session_013kDwmPmYtbENLcfMzDdnNF)_