### PR TITLE
azure-voyage-rpg: 強化 UI/UX 與 P0/P1 內容循環

### DIFF
--- a/azure-voyage-rpg/apps/web/src/app/globals.css
+++ b/azure-voyage-rpg/apps/web/src/app/globals.css
@@ -1357,3 +1357,45 @@ body {
     bottom: 1rem;
   }
 }
+
+.game-hotkey-hint {
+  @apply mt-2 text-xs tracking-[0.08em] text-foam/60;
+}
+
+.choice-btn {
+  @apply flex items-center gap-2;
+}
+
+.choice-shortcut {
+  @apply inline-flex min-w-5 items-center justify-center rounded-md border border-foam/20 bg-abyss/45 px-1.5 py-0.5 text-xs font-semibold text-gold;
+}
+
+.btn:focus-visible,
+.btn-ghost:focus-visible,
+.scene-hotspot:focus-visible,
+.route-area-node:focus-visible,
+.route-scene-node:focus-visible,
+.choice-btn:focus-visible {
+  outline: 2px solid rgba(246, 207, 125, 0.9);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  .scene-stage-backdrop,
+  .scene-gallery-image,
+  .speaker-portrait-image,
+  .battle-cinematic-backdrop,
+  .scene-stage-weather-backdrop,
+  .scene-stage-weather-fallback {
+    transform: none !important;
+  }
+}

--- a/azure-voyage-rpg/apps/web/src/game/GameClient.tsx
+++ b/azure-voyage-rpg/apps/web/src/game/GameClient.tsx
@@ -236,6 +236,39 @@ export function GameClient() {
     return () => window.clearTimeout(timer);
   }, [scene, state.currentSceneId]);
 
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || event.metaKey || event.ctrlKey || event.altKey) return;
+      const target = event.target as HTMLElement | null;
+      if (target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable)) {
+        return;
+      }
+
+      if ((event.key === "j" || event.key === "J") && !event.repeat) {
+        event.preventDefault();
+        setShowJournal((value) => !value);
+        return;
+      }
+
+      if (activeNode?.kind === "choice") {
+        const optionIndex = Number(event.key) - 1;
+        if (Number.isInteger(optionIndex) && optionIndex >= 0 && optionIndex < activeNode.options.length) {
+          event.preventDefault();
+          handleChoose(optionIndex);
+        }
+        return;
+      }
+
+      if (event.key === "Enter" && (activeNode?.kind === "dialogue" || activeNode?.kind === "checkResult")) {
+        event.preventDefault();
+        handleContinue();
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [activeNode, handleChoose, handleContinue]);
+
   const questSummaries = useMemo(
     () =>
       Object.values(content.quests)
@@ -296,6 +329,7 @@ export function GameClient() {
           <p className="mt-1 text-sm text-foam/80">
             第 {state.clock.day} 日・{PHASE_LABELS[state.clock.phase]}・{SEASON_LABELS[state.clock.season]}季
           </p>
+          <p className="game-hotkey-hint">快捷鍵：J 切換日誌／Enter 繼續／1-9 選項</p>
         </div>
         <div className="game-stat-row">
           {Object.entries(STAT_LABELS).map(([stat, label]) => (
@@ -306,7 +340,7 @@ export function GameClient() {
           ))}
         </div>
         <div className="flex flex-wrap gap-2">
-          <button className="btn-ghost" onClick={() => setShowJournal((v) => !v)}>
+          <button className="btn-ghost" onClick={() => setShowJournal((v) => !v)} title="快捷鍵 J">
             {showJournal ? "收起任務" : "展開任務"}
           </button>
           <button className="btn-ghost" onClick={handleNewGame}>
@@ -384,7 +418,11 @@ export function GameClient() {
             onWait={handleWait}
           />
 
-          {notice && <section className="panel notice-banner">{notice}</section>}
+          {notice && (
+            <section className="panel notice-banner" role="status" aria-live="polite">
+              {notice}
+            </section>
+          )}
 
           {activeNode ? (
             <section className="panel dialogue-panel">
@@ -393,7 +431,7 @@ export function GameClient() {
               {activeNode.kind === "dialogue" && activeSpeaker && (
                 <div className="dialogue-layout">
                   <SpeakerPortraitCard speaker={activeSpeaker} />
-                  <div className="dialogue-bubble" key={`${activeNode.speaker}:${activeNode.text}`}>
+                  <div className="dialogue-bubble" key={`${activeNode.speaker}:${activeNode.text}`} role="status" aria-live="polite">
                     <p className="dialogue-speaker" style={{ color: activeSpeaker.accentColor }}>
                       {activeNode.speaker}
                     </p>
@@ -406,7 +444,7 @@ export function GameClient() {
               )}
 
               {activeNode.kind === "checkResult" && (
-                <div className="dialogue-bubble system-bubble">
+                <div className="dialogue-bubble system-bubble" role="status" aria-live="polite">
                   <p className="dialogue-speaker">
                     {STAT_LABELS[activeNode.stat]}判定・門檻 {activeNode.difficulty}
                   </p>
@@ -424,8 +462,9 @@ export function GameClient() {
                   <p className="dialogue-speaker">你的選擇</p>
                   <p className="dialogue-text">{activeNode.prompt}</p>
                   <div className="choice-grid">
-                    {activeNode.options.map((opt) => (
+                    {activeNode.options.map((opt, choiceIndex) => (
                       <button key={opt.index} className="btn-ghost choice-btn" onClick={() => handleChoose(opt.index)}>
+                        <span className="choice-shortcut">{choiceIndex + 1}.</span>
                         {opt.label}
                       </button>
                     ))}

--- a/azure-voyage-rpg/apps/web/src/game/SceneStage.tsx
+++ b/azure-voyage-rpg/apps/web/src/game/SceneStage.tsx
@@ -173,6 +173,8 @@ export function SceneStage({
                   style={{ left: `${position.x}%`, top: `${position.y}%` }}
                   onClick={() => onInteract(hotspot.id)}
                   disabled={!!activeNode}
+                  title={hotspot.label}
+                  aria-label={`互動：${hotspot.label}`}
                 >
                   <span className="scene-hotspot-ping" />
                   <span className="scene-hotspot-label">{hotspot.label}</span>

--- a/azure-voyage-rpg/packages/content/src/content.test.ts
+++ b/azure-voyage-rpg/packages/content/src/content.test.ts
@@ -104,8 +104,50 @@ describe("main quest chain playthrough (favorable rng)", () => {
     expect(engine.state.inventory).toContain("item.perlan_salt");
     expect(engine.state.reputation["area.perlan"]).toBe(10);
 
-    // ── 主線任務目標此刻應全數判定為完成 ──
-    for (const questId of ["quest.ch1_first_trade", "quest.ch2_crew", "quest.ch3_first_battle", "quest.side_perlan"]) {
+    // ── P0/P1 內容循環：市場補給單 → 酒館演練 → 佩爾蘭船隊護送 ──
+    engine.advanceTime(2); // DUSK -> NIGHT -> DAWN（市場開門）
+    engine.travelTo("scene.aurelia.market");
+    node = engine.interact("hotspot.market.stalls");
+    expect(node?.kind).toBe("dialogue");
+    node = drain(engine);
+    expect(node.kind).toBe("choice");
+    node = engine.choose(1); // 走高價風險單（trade check）
+    expect(node.kind).toBe("checkResult");
+    node = drain(engine);
+    expect(node.kind).toBe("end");
+    expect(engine.state.flags).toContain("flag.supply_contract_signed");
+
+    engine.advanceTime(1); // DAY -> DUSK（酒館開門）
+    engine.travelTo("scene.aurelia.tavern");
+    node = engine.interact("hotspot.tavern.corner_table");
+    expect(node?.kind).toBe("dialogue");
+    node = drain(engine);
+    expect(node.kind).toBe("choice");
+    node = engine.choose(0); // 砲位協同演練（combat check）
+    expect(node.kind).toBe("checkResult");
+    node = drain(engine);
+    expect(node.kind).toBe("end");
+    expect(engine.state.flags).toContain("flag.crew_drill_done");
+
+    engine.travelTo("scene.perlan.docks");
+    node = engine.interact("hotspot.perlan.old_fisherman");
+    expect(node?.kind).toBe("dialogue");
+    node = drain(engine);
+    expect(node.kind).toBe("choice");
+    node = engine.choose(0); // 親自護送（nav check）
+    expect(node.kind).toBe("checkResult");
+    node = drain(engine);
+    expect(node.kind).toBe("end");
+    expect(engine.state.flags).toContain("flag.perlan_convoy_secured");
+
+    // ── 主線 + P1 支線任務目標此刻應全數判定為完成 ──
+    for (const questId of [
+      "quest.ch1_first_trade",
+      "quest.ch2_crew",
+      "quest.ch3_first_battle",
+      "quest.side_perlan",
+      "quest.side_supply_line",
+    ]) {
       const quest = content.quests[questId];
       for (const objective of quest.objectives) {
         expect(evaluateCondition(objective.completeWhen, engine.state)).toBe(true);

--- a/azure-voyage-rpg/packages/content/src/events/market.ts
+++ b/azure-voyage-rpg/packages/content/src/events/market.ts
@@ -53,6 +53,99 @@ export const MARKET_EVENTS: Record<string, GameEvent> = {
       },
     ],
   },
+  "event.market.bulk_contract": {
+    id: "event.market.bulk_contract",
+    precondition: {
+      kind: "and",
+      all: [
+        { kind: "flag", flag: "flag.first_trade_done", value: true },
+        { kind: "flag", flag: "flag.crew_assembled", value: true },
+      ],
+    },
+    weight: 70,
+    once: false,
+    cooldownDays: 1,
+    entryNodeId: "n1",
+    nodes: [
+      {
+        kind: "dialogue",
+        id: "n1",
+        speaker: "市場掮客",
+        text: "「來得正好，」掮客把一張急單推過來，「兩批補給今晚就要出港。你要接穩單，還是賭高價那批？」",
+        goto: "n2",
+      },
+      {
+        kind: "choice",
+        id: "n2",
+        prompt: "你要怎麼接這份急單？",
+        options: [
+          { label: "接穩定補給線，利潤薄但風險低", goto: "n_safe_effect" },
+          { label: "吃下高價風險單，試著賺一筆大的", goto: "check_trade" },
+        ],
+      },
+      {
+        kind: "effect",
+        id: "n_safe_effect",
+        effect: {
+          setFlags: ["flag.supply_contract_signed"],
+          reputation: [{ area: "area.aurelia", delta: 3 }],
+          worldState: [{ path: "crimsonThreat", delta: -1 }],
+          advanceTime: 1,
+        },
+        goto: "n_safe_close",
+      },
+      {
+        kind: "dialogue",
+        id: "n_safe_close",
+        speaker: "賽菈",
+        text: "「錢少一點，但帳面很乾淨，」賽菈點頭，「我們先把航線跑穩，商會才站得住。」",
+        goto: "END",
+      },
+      {
+        kind: "skillCheck",
+        id: "check_trade",
+        stat: "trade",
+        difficulty: 26,
+        onSuccess: "n_risk_win",
+        onFailure: "n_risk_fail",
+      },
+      {
+        kind: "dialogue",
+        id: "n_risk_win",
+        speaker: "旁白",
+        text: "你在最後一刻談下有利條款，貨單價格被你抬高了一截，港邊商販對晨汐商會另眼相看。",
+        goto: "n_risk_win_effect",
+      },
+      {
+        kind: "effect",
+        id: "n_risk_win_effect",
+        effect: {
+          setFlags: ["flag.supply_contract_signed"],
+          reputation: [{ area: "area.aurelia", delta: 4 }],
+          worldState: [{ path: "crimsonThreat", delta: 1 }],
+          advanceTime: 1,
+        },
+        goto: "END",
+      },
+      {
+        kind: "dialogue",
+        id: "n_risk_fail",
+        speaker: "旁白",
+        text: "你沒能壓住對方條件，高價單的保費和延誤罰金反咬一口。這趟不至於致命，卻讓你記得貪快的代價。",
+        goto: "n_risk_fail_effect",
+      },
+      {
+        kind: "effect",
+        id: "n_risk_fail_effect",
+        effect: {
+          setFlags: ["flag.supply_contract_signed"],
+          worldState: [{ path: "crimsonThreat", delta: 2 }],
+          advanceTime: 1,
+        },
+        goto: "END",
+      },
+    ],
+  },
   "event.market.crimson_scout": {
     id: "event.market.crimson_scout",
     precondition: {

--- a/azure-voyage-rpg/packages/content/src/events/opening.ts
+++ b/azure-voyage-rpg/packages/content/src/events/opening.ts
@@ -85,4 +85,36 @@ export const OPENING_EVENTS: Record<string, GameEvent> = {
       },
     ],
   },
+  "event.harbor_office.risk_bulletin": {
+    id: "event.harbor_office.risk_bulletin",
+    precondition: {
+      kind: "and",
+      all: [
+        { kind: "flag", flag: "flag.game_started", value: true },
+        { kind: "flag", flag: "flag.first_trade_done", value: true },
+      ],
+    },
+    weight: 35,
+    once: false,
+    cooldownDays: 1,
+    entryNodeId: "n1",
+    nodes: [
+      {
+        kind: "dialogue",
+        id: "n1",
+        speaker: "公告欄",
+        text: "你發現新貼上的航運告示：『三日內完成物資配送的商會，將獲得下一輪港務靠泊優先權。』旁邊有人補註：『晚到一天，保費翻倍。』",
+        goto: "n2",
+      },
+      {
+        kind: "effect",
+        id: "n2",
+        effect: {
+          setFlags: ["flag.risk_bulletin_seen"],
+          worldState: [{ path: "crimsonThreat", delta: 1 }],
+        },
+        goto: "END",
+      },
+    ],
+  },
 };

--- a/azure-voyage-rpg/packages/content/src/events/perlan.ts
+++ b/azure-voyage-rpg/packages/content/src/events/perlan.ts
@@ -93,4 +93,87 @@ export const PERLAN_EVENTS: Record<string, GameEvent> = {
       },
     ],
   },
+  "event.perlan.supply_convoy": {
+    id: "event.perlan.supply_convoy",
+    precondition: {
+      kind: "and",
+      all: [
+        { kind: "flag", flag: "flag.perlan_quest_completed", value: true },
+        { kind: "flag", flag: "flag.first_battle_done", value: true },
+      ],
+    },
+    weight: 70,
+    once: false,
+    cooldownDays: 2,
+    entryNodeId: "n1",
+    nodes: [
+      {
+        kind: "dialogue",
+        id: "n1",
+        speaker: "圖克·佩蘭",
+        text: "「今晚有兩條小艇要把鹽送過外海岬角，」圖克壓低聲音，「那段水路最近不太平，你要不要帶人壓一程？」",
+        goto: "n2",
+      },
+      {
+        kind: "choice",
+        id: "n2",
+        prompt: "你打算怎麼處理這次護送？",
+        options: [
+          { label: "親自帶船護送，走外海快線", goto: "check_nav" },
+          { label: "讓布拉姆帶隊，自己留港統籌補給", goto: "check_lead" },
+        ],
+      },
+      {
+        kind: "skillCheck",
+        id: "check_nav",
+        stat: "nav",
+        difficulty: 23,
+        onSuccess: "n_success",
+        onFailure: "n_fail",
+      },
+      {
+        kind: "skillCheck",
+        id: "check_lead",
+        stat: "lead",
+        difficulty: 23,
+        onSuccess: "n_success",
+        onFailure: "n_fail",
+      },
+      {
+        kind: "dialogue",
+        id: "n_success",
+        speaker: "旁白",
+        text: "整支船隊在天亮前安全返港，佩爾蘭碼頭久違地亮起了慶祝的燈。鎏金天秤的採購代理也在場，默默記下了你的名字。",
+        goto: "n_success_effect",
+      },
+      {
+        kind: "effect",
+        id: "n_success_effect",
+        effect: {
+          setFlags: ["flag.perlan_convoy_secured"],
+          reputation: [{ area: "area.perlan", delta: 4 }, { area: "area.aurelia", delta: 2 }],
+          worldState: [{ path: "crimsonThreat", delta: -1 }],
+          advanceTime: 1,
+        },
+        goto: "END",
+      },
+      {
+        kind: "dialogue",
+        id: "n_fail",
+        speaker: "旁白",
+        text: "船隊還是回來了，但丟了半船貨，還有兩名水手受了傷。圖克沒有責怪你，只是把帳本往後翻了一頁。",
+        goto: "n_fail_effect",
+      },
+      {
+        kind: "effect",
+        id: "n_fail_effect",
+        effect: {
+          setFlags: ["flag.perlan_convoy_secured"],
+          worldState: [{ path: "crimsonThreat", delta: 2 }],
+          advanceTime: 1,
+        },
+        goto: "END",
+      },
+    ],
+  },
 };

--- a/azure-voyage-rpg/packages/content/src/events/tavern.ts
+++ b/azure-voyage-rpg/packages/content/src/events/tavern.ts
@@ -131,4 +131,87 @@ export const TAVERN_EVENTS: Record<string, GameEvent> = {
       },
     ],
   },
+  "event.tavern.crew_drill": {
+    id: "event.tavern.crew_drill",
+    precondition: {
+      kind: "and",
+      all: [
+        { kind: "flag", flag: "flag.crew_assembled", value: true },
+        { kind: "flag", flag: "flag.first_battle_done", value: true },
+      ],
+    },
+    weight: 80,
+    once: false,
+    cooldownDays: 1,
+    entryNodeId: "n1",
+    nodes: [
+      {
+        kind: "dialogue",
+        id: "n1",
+        speaker: "布拉姆",
+        text: "「下一次碰上緋帆團，別想靠運氣。」布拉姆把木杯往桌上一放，「今晚先演練一輪登船接戰流程。」",
+        goto: "n2",
+      },
+      {
+        kind: "choice",
+        id: "n2",
+        prompt: "你要把訓練重點放在哪？",
+        options: [
+          { label: "砲位協同與換裝節奏", goto: "check_combat" },
+          { label: "夜航變陣與口令同步", goto: "check_lead" },
+        ],
+      },
+      {
+        kind: "skillCheck",
+        id: "check_combat",
+        stat: "combat",
+        difficulty: 24,
+        onSuccess: "n_success",
+        onFailure: "n_fail",
+      },
+      {
+        kind: "skillCheck",
+        id: "check_lead",
+        stat: "lead",
+        difficulty: 22,
+        onSuccess: "n_success",
+        onFailure: "n_fail",
+      },
+      {
+        kind: "dialogue",
+        id: "n_success",
+        speaker: "賽菈",
+        text: "「這次節奏對了，」賽菈把演練紀錄遞給你，「照這樣練下去，下次損失會小很多。」",
+        goto: "n_success_effect",
+      },
+      {
+        kind: "effect",
+        id: "n_success_effect",
+        effect: {
+          setFlags: ["flag.crew_drill_done"],
+          reputation: [{ area: "area.aurelia", delta: 2 }],
+          worldState: [{ path: "crimsonThreat", delta: -1 }],
+          advanceTime: 1,
+        },
+        goto: "END",
+      },
+      {
+        kind: "dialogue",
+        id: "n_fail",
+        speaker: "布拉姆",
+        text: "「動作還是亂，」布拉姆皺眉，「至少你們知道問題在哪。明晚再來一次。」",
+        goto: "n_fail_effect",
+      },
+      {
+        kind: "effect",
+        id: "n_fail_effect",
+        effect: {
+          setFlags: ["flag.crew_drill_done"],
+          worldState: [{ path: "crimsonThreat", delta: 1 }],
+          advanceTime: 1,
+        },
+        goto: "END",
+      },
+    ],
+  },
 };

--- a/azure-voyage-rpg/packages/content/src/quests.ts
+++ b/azure-voyage-rpg/packages/content/src/quests.ts
@@ -68,4 +68,35 @@ export const QUESTS: Record<string, Quest> = {
     ],
     rewards: {},
   },
+  "quest.side_supply_line": {
+    id: "quest.side_supply_line",
+    kind: "SIDE",
+    title: "商會補給線",
+    giver: "npc.sera",
+    precondition: {
+      kind: "and",
+      all: [
+        { kind: "flag", flag: "flag.first_trade_done", value: true },
+        { kind: "flag", flag: "flag.crew_assembled", value: true },
+      ],
+    },
+    objectives: [
+      {
+        id: "obj.sign_supply_contract",
+        description: "在中央市場簽下第一份穩定補給單",
+        completeWhen: { kind: "flag", flag: "flag.supply_contract_signed", value: true },
+      },
+      {
+        id: "obj.finish_crew_drill",
+        description: "在酒館完成一次夜間班底演練",
+        completeWhen: { kind: "flag", flag: "flag.crew_drill_done", value: true },
+      },
+      {
+        id: "obj.secure_perlan_convoy",
+        description: "護送佩爾蘭補給船隊安全返港",
+        completeWhen: { kind: "flag", flag: "flag.perlan_convoy_secured", value: true },
+      },
+    ],
+    rewards: {},
+  },
 };

--- a/azure-voyage-rpg/packages/content/src/scenes/aurelia.ts
+++ b/azure-voyage-rpg/packages/content/src/scenes/aurelia.ts
@@ -32,7 +32,7 @@ export const AURELIA_SCENES: Record<string, Scene> = {
       {
         id: "hotspot.harbor_office.notice_board",
         label: "公告欄",
-        eventPool: ["event.harbor_office.rumor"],
+        eventPool: ["event.harbor_office.rumor", "event.harbor_office.risk_bulletin"],
         visibleIf: { kind: "flag", flag: "flag.game_started", value: true },
         position: { x: 74, y: 38 },
       },
@@ -70,7 +70,7 @@ export const AURELIA_SCENES: Record<string, Scene> = {
       {
         id: "hotspot.tavern.corner_table",
         label: "角落的桌子",
-        eventPool: ["event.tavern.crimson_rumor"],
+        eventPool: ["event.tavern.crimson_rumor", "event.tavern.crew_drill"],
         visibleIf: { kind: "flag", flag: "flag.game_started", value: true },
         position: { x: 72, y: 58 },
       },
@@ -101,7 +101,7 @@ export const AURELIA_SCENES: Record<string, Scene> = {
       {
         id: "hotspot.market.stalls",
         label: "貨攤",
-        eventPool: ["event.market.first_trade"],
+        eventPool: ["event.market.first_trade", "event.market.bulk_contract"],
         visibleIf: { kind: "flag", flag: "flag.game_started", value: true },
         position: { x: 34, y: 67 },
       },

--- a/azure-voyage-rpg/packages/content/src/scenes/perlan.ts
+++ b/azure-voyage-rpg/packages/content/src/scenes/perlan.ts
@@ -25,7 +25,7 @@ export const PERLAN_SCENES: Record<string, Scene> = {
       {
         id: "hotspot.perlan.old_fisherman",
         label: "老漁夫圖克",
-        eventPool: ["event.perlan.meet_tuk", "event.perlan.saltfield_reopened"],
+        eventPool: ["event.perlan.meet_tuk", "event.perlan.saltfield_reopened", "event.perlan.supply_convoy"],
         position: { x: 62, y: 66 },
       },
     ],


### PR DESCRIPTION
## Summary
- Improved gameplay UX and accessibility in the web client:
  - Keyboard shortcuts (`J`, `Enter`, `1-9`)
  - Better focus-visible states and aria-live/status regions
  - Reduced-motion support for animation-heavy scenes
- Expanded P0/P1 content depth and replay loop in content pack:
  - New repeatable events for harbor office, tavern, market, and Perlan docks
  - Added `quest.side_supply_line` to connect the new progression loop
  - Updated scene hotspot pools to include new event chains
- Extended `content.test.ts` playthrough coverage for the new side-loop progression.

## Why
- Increase retention and session depth before launch by adding meaningful repeatable loops.
- Improve accessibility and interaction fluency for keyboard and motion-sensitive users.

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

## Notes
- Scoped commit to `azure-voyage-rpg/*` only; unrelated dirty files in `azure-voyage/*` were intentionally excluded.