### PR TITLE
azure-voyage-rpg: 存檔穩定性 + 觀測性埋點 + SLO 定義

### DIFF
--- a/azure-voyage-rpg/README.md
+++ b/azure-voyage-rpg/README.md
@@ -42,9 +42,233 @@ pnpm build
 - 每個場景可用 `SceneVisual.theme` 指定專屬動畫主題包（港務廳文件塵霧／酒館爐火煙霧／市場帆旗人流／佩爾蘭潮霧燈號）。
 - 主題包支援 content 端可配置：場景可用 `SceneVisual.themePresetId` 引用 `packages/content/src/themePresets.ts` 的共用模板，並可透過 `SceneVisual.themeTemplate` 做局部覆寫；未指定時會回退到 `apps/web/src/game/sceneThemeTemplates.ts` 的主題預設。
 
+## 上線前觀測性（P0/P1）
+
+- 前端埋點與錯誤回報位於 `apps/web/src/lib/telemetry.ts`。
+- 遊戲核心流程（互動、選項、轉場、等待、新開局）會送出結構化事件。
+- 另有全域 `window.error` / `unhandledrejection` 監聽（`RuntimeMonitor`）補捉前端 runtime 例外。
+- 透過環境變數控制：
+  - `NEXT_PUBLIC_OBSERVABILITY_ENABLED=1`：啟用觀測事件
+  - `NEXT_PUBLIC_OBSERVABILITY_ENDPOINT=https://...`：送往你的 collector（未設定時退回 console）
+
+### P1.5 事件 schema 對照表
+
+事件基礎欄位（所有事件共用）：
+
+- `source`: `azure-voyage-rpg-web`
+- `level`: `info | error`
+- `event`: 事件名稱
+- `timestamp`: ISO 時間
+- `sessionId`: 單次遊玩 session id
+- `pathname`: 前端路徑
+- `payload`: 事件細節（見下表）
+
+| event | level | payload keys |
+| --- | --- | --- |
+| `session.start` | info | `sceneId`, `day`, `phase`, `saveStatus` |
+| `gameplay.interact.hit` | info | `hotspotId`, `sceneId`, `day`, `phase`, `nextNodeKind` |
+| `gameplay.interact.miss` | info | `hotspotId`, `sceneId`, `day`, `phase` |
+| `gameplay.continue` | info | `fromNodeKind`, `toNodeKind`, `sceneId`, `day` |
+| `gameplay.choice.select` | info | `choiceIndex`, `toNodeKind`, `sceneId`, `day` |
+| `gameplay.wait.advance_time` | info | `fromDay`, `fromPhase`, `toDay`, `toPhase`, `sceneId` |
+| `gameplay.travel.scene` | info | `fromSceneId`, `toSceneId`, `day`, `phase` |
+| `gameplay.travel.scene_failed` | error | `fromSceneId`, `toSceneId`, `errorName`, `errorMessage` |
+| `gameplay.travel.area` | info | `fromAreaId`, `toAreaId`, `toSceneId`, `day`, `phase` |
+| `gameplay.travel.area_failed` | error | `toAreaId`, `toSceneId`, `errorName`, `errorMessage` |
+| `gameplay.new_game.confirmed` | info | `previousPlaythrough`, `previousDay`, `previousSceneId` |
+| `gameplay.transition` | info | `kind`, `label`, `fromSceneId`, `toSceneId`, `day`, `phase` |
+| `runtime.window.error` | error | `filename`, `line`, `column`, `errorName`, `errorMessage` |
+| `runtime.window.unhandled_rejection` | error | `errorName`, `errorMessage` |
+
+Schema 常數來源：`apps/web/src/lib/telemetry.ts` 的 `TELEMETRY_EVENT_SCHEMA`。
+
+### P1.5 dashboard 查詢範本
+
+> 假設資料表/索引內含欄位：`timestamp`, `event`, `level`, `sessionId`, `pathname`, `payload`（JSON）。
+
+#### BigQuery（JSON payload）
+
+```sql
+-- 1) 每日錯誤率（error / all）
+WITH base AS (
+  SELECT DATE(timestamp) AS d, level
+  FROM `project.dataset.telemetry_events`
+  WHERE source = 'azure-voyage-rpg-web'
+    AND timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 14 DAY)
+)
+SELECT
+  d,
+  COUNTIF(level = 'error') AS error_count,
+  COUNT(*) AS total_count,
+  SAFE_DIVIDE(COUNTIF(level = 'error'), COUNT(*)) AS error_rate
+FROM base
+GROUP BY d
+ORDER BY d;
+```
+
+```sql
+-- 2) 互動命中率（interact hit ratio）
+SELECT
+  DATE(timestamp) AS d,
+  COUNTIF(event = 'gameplay.interact.hit') AS hit_count,
+  COUNTIF(event IN ('gameplay.interact.hit', 'gameplay.interact.miss')) AS total_interact,
+  SAFE_DIVIDE(
+    COUNTIF(event = 'gameplay.interact.hit'),
+    COUNTIF(event IN ('gameplay.interact.hit', 'gameplay.interact.miss'))
+  ) AS hit_ratio
+FROM `project.dataset.telemetry_events`
+WHERE source = 'azure-voyage-rpg-web'
+  AND timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 14 DAY)
+GROUP BY d
+ORDER BY d;
+```
+
+```sql
+-- 3) 場景卡點排行（travel failed）
+SELECT
+  JSON_VALUE(payload, '$.toSceneId') AS to_scene_id,
+  JSON_VALUE(payload, '$.errorMessage') AS error_message,
+  COUNT(*) AS fail_count
+FROM `project.dataset.telemetry_events`
+WHERE source = 'azure-voyage-rpg-web'
+  AND event IN ('gameplay.travel.scene_failed', 'gameplay.travel.area_failed')
+  AND timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 14 DAY)
+GROUP BY to_scene_id, error_message
+ORDER BY fail_count DESC
+LIMIT 20;
+```
+
+#### Datadog（Log/Analytics）
+
+- Total events：`source:azure-voyage-rpg-web`
+- Error events：`source:azure-voyage-rpg-web @level:error`
+- Error rate 監控：`A = errors`, `B = total`, monitor 設 `A/B > 0.02`（可依實際調整）
+- Travel failure Top list：`@event:(gameplay.travel.scene_failed OR gameplay.travel.area_failed)` group by `@payload.toSceneId`
+- Runtime exceptions：`@event:(runtime.window.error OR runtime.window.unhandled_rejection)` group by `@payload.errorName`
+
+#### Grafana Loki（LogQL）
+
+```logql
+# 1) 每 5 分鐘 error 事件速率
+sum(rate({source="azure-voyage-rpg-web", level="error"}[5m]))
+```
+
+```logql
+# 2) 轉場失敗速率
+sum(rate({source="azure-voyage-rpg-web"} |= "gameplay.travel.scene_failed" [5m]))
++ sum(rate({source="azure-voyage-rpg-web"} |= "gameplay.travel.area_failed" [5m]))
+```
+
+```logql
+# 3) runtime error 趨勢
+sum(rate({source="azure-voyage-rpg-web"} |= "runtime.window.error" [5m]))
++ sum(rate({source="azure-voyage-rpg-web"} |= "runtime.window.unhandled_rejection" [5m]))
+```
+
+### P1.6 SLO / Alert 門檻預設
+
+SLO 設定來源：`apps/web/src/lib/telemetry-slo.ts`（`SLO_DEFINITIONS`）。  
+下表為預設值，上線穩定後可視實際量收緊。
+
+| SLO ID | 名稱 | 視窗 | 門檻 | 觸發邏輯 | 嚴重度 |
+| --- | --- | --- | --- | --- | --- |
+| `slo.error_rate` | 整體 error rate | 5 min | > 3 % | error / all events | P1 |
+| `slo.error_rate_hourly` | 整體 error rate（1 hr） | 60 min | > 2 % | error / all events | P2 |
+| `slo.travel_fail_rate` | travel fail rate | 5 min | > 5 % | travel_failed / all_travel | P1 |
+| `slo.runtime_exception_burst` | runtime exception burst | 5 min | > 10 次 | runtime.window.\* count | P1 |
+| `slo.interact_hit_ratio` | interact 命中率下限 | 60 min | < 30 % | hit / (hit + miss) | P2 |
+
+#### Datadog Monitor YAML（可直接貼 terraform / DD CLI）
+
+```yaml
+# SLO-1: Error rate (P1)
+monitors:
+  - name: "[azure-voyage-rpg] Error rate > 3%"
+    type: log alert
+    query: >
+      logs("source:azure-voyage-rpg-web @level:error").rollup("count").last("5m")
+        / logs("source:azure-voyage-rpg-web").rollup("count").last("5m") > 0.03
+    message: |
+      @slack-alerts 整體 error rate 超過 3%，請立即查看。
+      Runbook：1. 查 runtime.window.error payload；2. 查 travel_failed toSceneId Top；3. 看 session.start.saveStatus。
+    priority: 1
+    thresholds: { critical: 0.03, warning: 0.02 }
+    evaluation_delay: 0
+    tags: [service:azure-voyage-rpg-web, slo:error_rate, env:prod]
+
+  # SLO-2: Travel fail rate (P1)
+  - name: "[azure-voyage-rpg] Travel fail rate > 5%"
+    type: log alert
+    query: >
+      logs("source:azure-voyage-rpg-web @event:(gameplay.travel.scene_failed OR gameplay.travel.area_failed)").rollup("count").last("5m")
+        / logs("source:azure-voyage-rpg-web @event:(gameplay.travel.scene OR gameplay.travel.area OR gameplay.travel.scene_failed OR gameplay.travel.area_failed)").rollup("count").last("5m") > 0.05
+    message: |
+      @slack-alerts Travel 失敗率超標，查 toSceneId 前幾名。
+    priority: 1
+    thresholds: { critical: 0.05, warning: 0.03 }
+    tags: [service:azure-voyage-rpg-web, slo:travel_fail_rate, env:prod]
+
+  # SLO-3: Runtime exception burst (P1)
+  - name: "[azure-voyage-rpg] Runtime exception burst > 10 in 5m"
+    type: log alert
+    query: >
+      logs("source:azure-voyage-rpg-web @event:(runtime.window.error OR runtime.window.unhandled_rejection)").rollup("count").last("5m") > 10
+    message: |
+      @slack-alerts Runtime exception burst（5 分鐘內超過 10 次）。
+      查 payload.errorName 確認類型，查 payload.filename 定位 chunk。
+    priority: 1
+    thresholds: { critical: 10, warning: 5 }
+    tags: [service:azure-voyage-rpg-web, slo:runtime_exception_burst, env:prod]
+```
+
+#### Grafana 告警規則（PromQL 等效）
+
+```yaml
+groups:
+  - name: azure-voyage-rpg-web.rules
+    interval: 1m
+    rules:
+      - alert: AzureVoyageRpgErrorRateHigh
+        expr: >
+          sum(rate(telemetry_events_total{source="azure-voyage-rpg-web",level="error"}[5m]))
+          / sum(rate(telemetry_events_total{source="azure-voyage-rpg-web"}[5m])) > 0.03
+        for: 2m
+        labels: { severity: critical, slo: error_rate }
+        annotations:
+          summary: "Error rate > 3% (5m)"
+          runbook: "查 runtime.window.error filename；查 travel_failed toSceneId"
+
+      - alert: AzureVoyageRpgTravelFailHigh
+        expr: >
+          sum(rate(telemetry_events_total{source="azure-voyage-rpg-web",event=~"gameplay\\.travel\\.(scene|area)_failed"}[5m]))
+          / sum(rate(telemetry_events_total{source="azure-voyage-rpg-web",event=~"gameplay\\.travel\\..*"}[5m])) > 0.05
+        for: 2m
+        labels: { severity: critical, slo: travel_fail_rate }
+        annotations:
+          summary: "Travel fail rate > 5% (5m)"
+
+      - alert: AzureVoyageRpgRuntimeExceptionBurst
+        expr: >
+          sum(increase(telemetry_events_total{source="azure-voyage-rpg-web",event=~"runtime\\.window\\..*"}[5m])) > 10
+        for: 0m
+        labels: { severity: critical, slo: runtime_exception_burst }
+        annotations:
+          summary: "Runtime exception burst > 10 in 5m"
+
+      - alert: AzureVoyageRpgLowInteractHitRatio
+        expr: >
+          sum(rate(telemetry_events_total{source="azure-voyage-rpg-web",event="gameplay.interact.hit"}[1h]))
+          / sum(rate(telemetry_events_total{source="azure-voyage-rpg-web",event=~"gameplay\\.interact\\.(hit|miss)"}[1h])) < 0.30
+        for: 5m
+        labels: { severity: warning, slo: interact_hit_ratio }
+        annotations:
+          summary: "Interact hit ratio < 30% (1h) — 內容空窗偏多"
+          runbook: "確認哪個 sceneId + hotspotId miss 最多；考慮加 P0 repeatable events"
+```
+
 ## 用 Docker 一鍵試玩
 
-純前端原型，不需要資料庫/佇列，存檔在瀏覽器 localStorage：
+純前端原型，不需要資料庫/佇列，存檔在瀏覽器 localStorage（含版本化封包與舊檔自動升級）：
 
 ```bash
 docker compose up --build

--- a/azure-voyage-rpg/apps/web/src/app/RuntimeMonitor.tsx
+++ b/azure-voyage-rpg/apps/web/src/app/RuntimeMonitor.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useEffect } from "react";
+import { reportError } from "@/lib/telemetry";
+
+export function RuntimeMonitor() {
+  useEffect(() => {
+    const onError = (event: ErrorEvent) => {
+      reportError("runtime.window.error", event.error ?? event.message, {
+        filename: event.filename ?? "",
+        line: event.lineno,
+        column: event.colno,
+      });
+    };
+    const onUnhandledRejection = (event: PromiseRejectionEvent) => {
+      reportError("runtime.window.unhandled_rejection", event.reason);
+    };
+
+    window.addEventListener("error", onError);
+    window.addEventListener("unhandledrejection", onUnhandledRejection);
+    return () => {
+      window.removeEventListener("error", onError);
+      window.removeEventListener("unhandledrejection", onUnhandledRejection);
+    };
+  }, []);
+
+  return null;
+}

--- a/azure-voyage-rpg/apps/web/src/app/layout.tsx
+++ b/azure-voyage-rpg/apps/web/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import { RuntimeMonitor } from "./RuntimeMonitor";
 
 export const metadata: Metadata = {
   title: "蒼瀾航路：晨汐紀事",
@@ -9,7 +10,10 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="zh-Hant">
-      <body>{children}</body>
+      <body>
+        <RuntimeMonitor />
+        {children}
+      </body>
     </html>
   );
 }

--- a/azure-voyage-rpg/apps/web/src/game/GameClient.tsx
+++ b/azure-voyage-rpg/apps/web/src/game/GameClient.tsx
@@ -13,6 +13,7 @@ import {
 } from "@azure-voyage-rpg/engine";
 import { AZURE_VOYAGE_RPG_CONTENT as content, createStartState } from "@azure-voyage-rpg/content";
 import { clearSave, loadSave, persistSave } from "@/lib/save";
+import { reportError, trackEvent } from "@/lib/telemetry";
 import { GameArt } from "@/game/GameArt";
 import { SceneStage } from "@/game/SceneStage";
 import { AudioDock } from "@/game/AudioDock";
@@ -107,9 +108,13 @@ function createSpeakerVisualIndex() {
   return index;
 }
 
-function makeEngine(): RpgEngine {
-  const saved = loadSave();
-  return new RpgEngine(content, saved ?? createStartState());
+function bootstrapGame() {
+  const loaded = loadSave();
+  return {
+    engine: new RpgEngine(content, loaded.state ?? createStartState()),
+    notice: loaded.notice,
+    saveStatus: loaded.status,
+  };
 }
 
 function monogram(name: string) {
@@ -131,9 +136,10 @@ function isBattleNarrativeText(text: string) {
 }
 
 export function GameClient() {
-  const [engine, setEngine] = useState<RpgEngine>(() => makeEngine());
+  const [bootstrap] = useState(bootstrapGame);
+  const [engine, setEngine] = useState<RpgEngine>(() => bootstrap.engine);
   const [activeNode, setActiveNode] = useState<PlayNode | null>(null);
-  const [notice, setNotice] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(() => bootstrap.notice);
   const [showJournal, setShowJournal] = useState(true);
   const [travelTransition, setTravelTransition] = useState<TravelTransition | null>(null);
 
@@ -152,32 +158,80 @@ export function GameClient() {
     setNotice(null);
     const node = engine.interact(hotspotId);
     if (!node) {
+      trackEvent("gameplay.interact.miss", {
+        hotspotId,
+        sceneId: engine.state.currentSceneId,
+        day: engine.state.clock.day,
+        phase: engine.state.clock.phase,
+      });
       setNotice("這個角落暫時沒有新的事件，但海風裡像還藏著下一段故事。");
       return;
     }
+    trackEvent("gameplay.interact.hit", {
+      hotspotId,
+      sceneId: engine.state.currentSceneId,
+      day: engine.state.clock.day,
+      phase: engine.state.clock.phase,
+      nextNodeKind: node.kind,
+    });
     settle(node);
   }
 
   function handleContinue() {
-    settle(engine.continue());
+    const beforeKind = activeNode?.kind ?? "idle";
+    const nextNode = engine.continue();
+    trackEvent("gameplay.continue", {
+      fromNodeKind: beforeKind,
+      toNodeKind: nextNode.kind,
+      sceneId: engine.state.currentSceneId,
+      day: engine.state.clock.day,
+    });
+    settle(nextNode);
   }
 
   function handleChoose(index: number) {
-    settle(engine.choose(index));
+    const nextNode = engine.choose(index);
+    trackEvent("gameplay.choice.select", {
+      choiceIndex: index,
+      toNodeKind: nextNode.kind,
+      sceneId: engine.state.currentSceneId,
+      day: engine.state.clock.day,
+    });
+    settle(nextNode);
   }
 
   function handleWait() {
     setNotice(null);
+    const beforePhase = engine.state.clock.phase;
+    const beforeDay = engine.state.clock.day;
     engine.advanceTime(1);
+    trackEvent("gameplay.wait.advance_time", {
+      fromDay: beforeDay,
+      fromPhase: beforePhase,
+      toDay: engine.state.clock.day,
+      toPhase: engine.state.clock.phase,
+      sceneId: engine.state.currentSceneId,
+    });
     sync();
   }
 
   function handleTravel(sceneId: string) {
     setNotice(null);
     try {
+      const fromSceneId = engine.state.currentSceneId;
       engine.travelTo(sceneId);
+      trackEvent("gameplay.travel.scene", {
+        fromSceneId,
+        toSceneId: sceneId,
+        day: engine.state.clock.day,
+        phase: engine.state.clock.phase,
+      });
       sync();
     } catch (err) {
+      reportError("gameplay.travel.scene_failed", err, {
+        fromSceneId: engine.state.currentSceneId,
+        toSceneId: sceneId,
+      });
       setNotice(err instanceof Error ? err.message : "現在還不能去那裡。");
     }
   }
@@ -187,15 +241,32 @@ export function GameClient() {
     const target = content.areas[areaId];
     const entryScene = target.scenes[0];
     try {
+      const fromAreaId = content.scenes[engine.state.currentSceneId]?.areaId ?? "";
       engine.travelTo(entryScene);
+      trackEvent("gameplay.travel.area", {
+        fromAreaId,
+        toAreaId: areaId,
+        toSceneId: entryScene,
+        day: engine.state.clock.day,
+        phase: engine.state.clock.phase,
+      });
       sync();
     } catch (err) {
+      reportError("gameplay.travel.area_failed", err, {
+        toAreaId: areaId,
+        toSceneId: entryScene,
+      });
       setNotice(err instanceof Error ? err.message : "現在還不能去那裡。");
     }
   }
 
   function handleNewGame() {
     if (!window.confirm("要放棄目前的存檔，重新開始一輪新旅程嗎？")) return;
+    trackEvent("gameplay.new_game.confirmed", {
+      previousPlaythrough: engine.state.playthrough,
+      previousDay: engine.state.clock.day,
+      previousSceneId: engine.state.currentSceneId,
+    });
     clearSave();
     const fresh = new RpgEngine(content, createStartState());
     setEngine(fresh);
@@ -215,6 +286,15 @@ export function GameClient() {
   const previousSceneIdRef = useRef(state.currentSceneId);
 
   useEffect(() => {
+    trackEvent("session.start", {
+      sceneId: bootstrap.engine.state.currentSceneId,
+      day: bootstrap.engine.state.clock.day,
+      phase: bootstrap.engine.state.clock.phase,
+      saveStatus: bootstrap.saveStatus,
+    });
+  }, [bootstrap]);
+
+  useEffect(() => {
     const previousSceneId = previousSceneIdRef.current;
     if (previousSceneId === state.currentSceneId) return;
 
@@ -230,6 +310,14 @@ export function GameClient() {
           : scene.name;
 
     setTravelTransition({ label, kind });
+    trackEvent("gameplay.transition", {
+      kind,
+      label,
+      fromSceneId: previousSceneId,
+      toSceneId: state.currentSceneId,
+      day: state.clock.day,
+      phase: state.clock.phase,
+    });
     previousSceneIdRef.current = state.currentSceneId;
 
     const timer = window.setTimeout(() => setTravelTransition(null), 1400);

--- a/azure-voyage-rpg/apps/web/src/lib/save.ts
+++ b/azure-voyage-rpg/apps/web/src/lib/save.ts
@@ -1,22 +1,98 @@
 import type { SaveState } from "@azure-voyage-rpg/engine";
 
 const SAVE_KEY = "azure-voyage-rpg.save.v1";
+const SAVE_VERSION = 2;
+
+interface SaveEnvelopeV2 {
+  version: 2;
+  savedAt: string;
+  state: SaveState;
+}
+
+export interface LoadSaveResult {
+  state: SaveState | null;
+  notice: string | null;
+  status: "empty" | "ok" | "migrated_v1" | "corrupted_reset" | "incompatible_reset";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+function isSaveState(value: unknown): value is SaveState {
+  if (!isRecord(value)) return false;
+  if (!isRecord(value.clock)) return false;
+  if (typeof value.clock.day !== "number") return false;
+  if (typeof value.clock.phase !== "string") return false;
+  if (typeof value.clock.season !== "string") return false;
+  if (!isStringArray(value.flags)) return false;
+  if (!isRecord(value.worldState)) return false;
+  if (!isRecord(value.affinity)) return false;
+  if (!isRecord(value.reputation)) return false;
+  if (!isRecord(value.exploration)) return false;
+  if (!isRecord(value.captainStats)) return false;
+  if (!isRecord(value.eventHistory)) return false;
+  if (!isRecord(value.questProgress)) return false;
+  if (!isRecord(value.unlocked)) return false;
+  if (!isStringArray(value.unlocked.regions)) return false;
+  if (!isStringArray(value.unlocked.areas)) return false;
+  if (!isStringArray(value.unlocked.scenes)) return false;
+  if (!isStringArray(value.inventory)) return false;
+  if (typeof value.playthrough !== "number") return false;
+  if (typeof value.currentSceneId !== "string") return false;
+  return true;
+}
+
+function parseJson(raw: string): { ok: true; value: unknown } | { ok: false } {
+  try {
+    return { ok: true, value: JSON.parse(raw) };
+  } catch (error) {
+    if (error instanceof SyntaxError) return { ok: false };
+    throw error;
+  }
+}
+
+function wrapV2Envelope(state: SaveState): SaveEnvelopeV2 {
+  return {
+    version: SAVE_VERSION,
+    savedAt: new Date().toISOString(),
+    state,
+  };
+}
 
 /** SaveState 全部由陣列/物件/純值構成（見 rpg-engine/types.ts），可直接 JSON 化。 */
-export function loadSave(): SaveState | null {
-  if (typeof window === "undefined") return null;
+export function loadSave(): LoadSaveResult {
+  if (typeof window === "undefined") return { state: null, notice: null, status: "empty" };
   const raw = window.localStorage.getItem(SAVE_KEY);
-  if (!raw) return null;
-  try {
-    return JSON.parse(raw) as SaveState;
-  } catch {
-    return null;
+  if (!raw) return { state: null, notice: null, status: "empty" };
+  const parsed = parseJson(raw);
+  if (!parsed.ok) {
+    window.localStorage.removeItem(SAVE_KEY);
+    return { state: null, notice: "偵測到損毀存檔，已自動重置為新旅程。", status: "corrupted_reset" };
   }
+
+  const value = parsed.value;
+  if (isRecord(value) && value.version === SAVE_VERSION && isSaveState(value.state)) {
+    return { state: value.state, notice: null, status: "ok" };
+  }
+
+  // v1: 直接存 SaveState，這裡做一次遷移並覆寫成 v2 envelope。
+  if (isSaveState(value)) {
+    window.localStorage.setItem(SAVE_KEY, JSON.stringify(wrapV2Envelope(value)));
+    return { state: value, notice: "已自動升級舊版存檔格式。", status: "migrated_v1" };
+  }
+
+  window.localStorage.removeItem(SAVE_KEY);
+  return { state: null, notice: "存檔格式不相容，已為你建立新的旅程。", status: "incompatible_reset" };
 }
 
 export function persistSave(state: SaveState): void {
   if (typeof window === "undefined") return;
-  window.localStorage.setItem(SAVE_KEY, JSON.stringify(state));
+  window.localStorage.setItem(SAVE_KEY, JSON.stringify(wrapV2Envelope(state)));
 }
 
 export function clearSave(): void {

--- a/azure-voyage-rpg/apps/web/src/lib/telemetry-slo.ts
+++ b/azure-voyage-rpg/apps/web/src/lib/telemetry-slo.ts
@@ -1,0 +1,155 @@
+/**
+ * P1.6 SLO/Alert 門檻設定（azure-voyage-rpg-web）
+ *
+ * 此模組宣告三條 SLO 及對應 alert 設定，可直接匯入至監控工具 SDK，
+ * 或作為設定 Datadog/Grafana/BigQuery Scheduled Alerts 的規格來源。
+ *
+ * 設計原則
+ * ─────────
+ * - 所有門檻皆保守（soft beta 標準），上線穩定後再收緊。
+ * - 計量視窗採 5 分鐘（短線告警）+ 1 小時（趨勢確認）兩層。
+ * - severity: P1 = 立即通知、P2 = 下個工作日處理。
+ */
+
+export type SloSeverity = 'P1' | 'P2';
+
+export interface SloDefinition {
+  /** SLO 識別 ID */
+  id: string;
+  /** 人類可讀名稱 */
+  name: string;
+  /** 計量視窗（分鐘） */
+  windowMinutes: number;
+  /** 觸發 alert 的門檻（依 metric 不同，意義各異） */
+  threshold: number;
+  /** 門檻單位說明 */
+  unit: string;
+  /** 嚴重程度 */
+  severity: SloSeverity;
+  /** 觸發條件說明（人類可讀） */
+  condition: string;
+  /** 計算所需事件集合 */
+  numeratorEvents: string[];
+  denominatorEvents?: string[];
+  /** 短版 runbook 提示（下一步查什麼） */
+  runbookHint: string;
+  /** 是否暫時停用（新版本初期觀察用） */
+  disabled?: boolean;
+}
+
+/**
+ * SLO 一覽。
+ *
+ * SLO-1  整體 error rate          — error 事件佔所有事件的比率
+ * SLO-2  travel fail rate         — travel 失敗佔所有 travel 的比率
+ * SLO-3  runtime exception burst  — 任何 5 分鐘視窗的 runtime 例外事件數
+ */
+export const SLO_DEFINITIONS = [
+  {
+    id: 'slo.error_rate',
+    name: '整體 error rate',
+    windowMinutes: 5,
+    threshold: 0.03,
+    unit: 'ratio (error / all events)',
+    severity: 'P1',
+    condition: 'error events / all events > 3 % in rolling 5 min window',
+    numeratorEvents: ['*'],
+    denominatorEvents: ['*'],
+    runbookHint:
+      '1. 查 runtime.window.error payload 的 filename/line 定位來源\n' +
+      '2. 查 gameplay.travel.*_failed 的 toSceneId 確認是否特定場景卡點\n' +
+      '3. 若是 save/load 問題，看 session.start.saveStatus 是否出現 corrupted_reset',
+  },
+  {
+    id: 'slo.error_rate_hourly',
+    name: '整體 error rate（1 小時確認）',
+    windowMinutes: 60,
+    threshold: 0.02,
+    unit: 'ratio (error / all events)',
+    severity: 'P2',
+    condition: 'error events / all events > 2 % in rolling 1 hour window',
+    numeratorEvents: ['*'],
+    denominatorEvents: ['*'],
+    runbookHint:
+      '趨勢超標但 5 分鐘不觸發 P1，代表緩發型問題（如特定場景高機率失敗）。\n' +
+      '查 BigQuery 每日錯誤率趨勢，確認上線後哪天開始升高。',
+  },
+  {
+    id: 'slo.travel_fail_rate',
+    name: 'travel fail rate',
+    windowMinutes: 5,
+    threshold: 0.05,
+    unit: 'ratio (travel_failed / all_travel)',
+    severity: 'P1',
+    condition:
+      '(gameplay.travel.scene_failed + gameplay.travel.area_failed) ' +
+      '/ (gameplay.travel.scene + gameplay.travel.area + failed) > 5 % in rolling 5 min',
+    numeratorEvents: [
+      'gameplay.travel.scene_failed',
+      'gameplay.travel.area_failed',
+    ],
+    denominatorEvents: [
+      'gameplay.travel.scene',
+      'gameplay.travel.area',
+      'gameplay.travel.scene_failed',
+      'gameplay.travel.area_failed',
+    ],
+    runbookHint:
+      '1. 依 toSceneId Top 排行找出問題場景\n' +
+      '2. 確認 content package 的 unlockCondition / timeGate 是否過嚴\n' +
+      '3. 若是 engine.travelTo 拋出未預期錯誤，檢查 engine version 是否有 hotfix',
+  },
+  {
+    id: 'slo.runtime_exception_burst',
+    name: 'runtime exception burst',
+    windowMinutes: 5,
+    threshold: 10,
+    unit: 'count (runtime errors in window)',
+    severity: 'P1',
+    condition:
+      '(runtime.window.error + runtime.window.unhandled_rejection) > 10 in rolling 5 min',
+    numeratorEvents: [
+      'runtime.window.error',
+      'runtime.window.unhandled_rejection',
+    ],
+    runbookHint:
+      '1. 查 payload.errorName 確認是不是同一個錯誤爆發\n' +
+      '2. 查 payload.filename 定位前端 chunk\n' +
+      '3. 若集中在 session.start 之後立刻爆發，可能是 save migration 或 content load 失敗',
+  },
+  {
+    id: 'slo.interact_hit_ratio',
+    name: 'interact 命中率下限',
+    windowMinutes: 60,
+    threshold: 0.3,
+    unit: 'ratio (hit / hit+miss)',
+    severity: 'P2',
+    condition:
+      'gameplay.interact.hit / (hit + miss) < 30 % in rolling 1 hour — ' +
+      '玩家大量觸發「沒有事件」代表內容空窗，不是 bug 但影響留存',
+    numeratorEvents: ['gameplay.interact.hit'],
+    denominatorEvents: ['gameplay.interact.hit', 'gameplay.interact.miss'],
+    runbookHint:
+      '1. 確認哪個 sceneId + hotspotId 組合 miss 最多\n' +
+      '2. 增加 P0/P1 repeatable events 填補空窗\n' +
+      '3. 確認事件 precondition 是否設太嚴',
+    disabled: false,
+  },
+] satisfies SloDefinition[];
+
+export type SloId =
+  | 'slo.error_rate'
+  | 'slo.error_rate_hourly'
+  | 'slo.travel_fail_rate'
+  | 'slo.runtime_exception_burst'
+  | 'slo.interact_hit_ratio';
+
+/** 取得單一 SLO（typesafe） */
+export function getSlo(id: SloId): SloDefinition {
+  return SLO_DEFINITIONS.find((s) => s.id === id) as SloDefinition;
+}
+
+/** 只列出啟用中（未 disabled）的 SLO */
+export function getActiveSlos(): SloDefinition[] {
+  return SLO_DEFINITIONS.filter((s) => !s.disabled);
+}

--- a/azure-voyage-rpg/apps/web/src/lib/telemetry.ts
+++ b/azure-voyage-rpg/apps/web/src/lib/telemetry.ts
@@ -1,0 +1,184 @@
+'use client';
+
+type TelemetryPrimitive = string | number | boolean | null;
+type TelemetryPayload = Record<string, TelemetryPrimitive>;
+type TelemetryLevel = 'info' | 'error';
+export type TelemetryEventName =
+  | 'session.start'
+  | 'gameplay.interact.hit'
+  | 'gameplay.interact.miss'
+  | 'gameplay.continue'
+  | 'gameplay.choice.select'
+  | 'gameplay.wait.advance_time'
+  | 'gameplay.travel.scene'
+  | 'gameplay.travel.scene_failed'
+  | 'gameplay.travel.area'
+  | 'gameplay.travel.area_failed'
+  | 'gameplay.new_game.confirmed'
+  | 'gameplay.transition'
+  | 'runtime.window.error'
+  | 'runtime.window.unhandled_rejection';
+
+interface TelemetryEvent {
+  source: 'azure-voyage-rpg-web';
+  level: TelemetryLevel;
+  event: TelemetryEventName;
+  timestamp: string;
+  sessionId: string;
+  pathname: string;
+  payload: TelemetryPayload;
+}
+
+export const TELEMETRY_EVENT_SCHEMA: Record<
+  TelemetryEventName,
+  { level: TelemetryLevel; payloadKeys: string[]; description: string }
+> = {
+  'session.start': {
+    level: 'info',
+    payloadKeys: ['sceneId', 'day', 'phase', 'saveStatus'],
+    description: 'Session bootstrap summary.',
+  },
+  'gameplay.interact.hit': {
+    level: 'info',
+    payloadKeys: ['hotspotId', 'sceneId', 'day', 'phase', 'nextNodeKind'],
+    description: 'Interaction found an eligible event.',
+  },
+  'gameplay.interact.miss': {
+    level: 'info',
+    payloadKeys: ['hotspotId', 'sceneId', 'day', 'phase'],
+    description: 'Interaction had no eligible event.',
+  },
+  'gameplay.continue': {
+    level: 'info',
+    payloadKeys: ['fromNodeKind', 'toNodeKind', 'sceneId', 'day'],
+    description: 'Continue in dialogue/check flow.',
+  },
+  'gameplay.choice.select': {
+    level: 'info',
+    payloadKeys: ['choiceIndex', 'toNodeKind', 'sceneId', 'day'],
+    description: 'Player selected a branching choice.',
+  },
+  'gameplay.wait.advance_time': {
+    level: 'info',
+    payloadKeys: ['fromDay', 'fromPhase', 'toDay', 'toPhase', 'sceneId'],
+    description: 'Player advanced time manually.',
+  },
+  'gameplay.travel.scene': {
+    level: 'info',
+    payloadKeys: ['fromSceneId', 'toSceneId', 'day', 'phase'],
+    description: 'Scene-to-scene travel success.',
+  },
+  'gameplay.travel.scene_failed': {
+    level: 'error',
+    payloadKeys: ['fromSceneId', 'toSceneId', 'errorName', 'errorMessage'],
+    description: 'Scene travel failed.',
+  },
+  'gameplay.travel.area': {
+    level: 'info',
+    payloadKeys: ['fromAreaId', 'toAreaId', 'toSceneId', 'day', 'phase'],
+    description: 'Area travel success.',
+  },
+  'gameplay.travel.area_failed': {
+    level: 'error',
+    payloadKeys: ['toAreaId', 'toSceneId', 'errorName', 'errorMessage'],
+    description: 'Area travel failed.',
+  },
+  'gameplay.new_game.confirmed': {
+    level: 'info',
+    payloadKeys: ['previousPlaythrough', 'previousDay', 'previousSceneId'],
+    description: 'Player confirmed reset/new game.',
+  },
+  'gameplay.transition': {
+    level: 'info',
+    payloadKeys: ['kind', 'label', 'fromSceneId', 'toSceneId', 'day', 'phase'],
+    description: 'Visual transition between scene/area.',
+  },
+  'runtime.window.error': {
+    level: 'error',
+    payloadKeys: ['filename', 'line', 'column', 'errorName', 'errorMessage'],
+    description: 'Window error event captured globally.',
+  },
+  'runtime.window.unhandled_rejection': {
+    level: 'error',
+    payloadKeys: ['errorName', 'errorMessage'],
+    description: 'Unhandled promise rejection captured globally.',
+  },
+};
+
+const OBS_ENABLED = process.env.NEXT_PUBLIC_OBSERVABILITY_ENABLED === '1';
+const OBS_ENDPOINT = process.env.NEXT_PUBLIC_OBSERVABILITY_ENDPOINT ?? '';
+const sessionId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+
+function normalizeError(error: unknown): { name: string; message: string } {
+  if (error instanceof Error) {
+    return { name: error.name, message: error.message };
+  }
+  return {
+    name: 'UnknownError',
+    message: typeof error === 'string' ? error : 'unknown error',
+  };
+}
+
+function enqueue(event: TelemetryEvent) {
+  if (!OBS_ENABLED) return;
+  if (!OBS_ENDPOINT) {
+    console.info('[obs:event]', event);
+    return;
+  }
+
+  const body = JSON.stringify(event);
+  if (
+    typeof navigator !== 'undefined' &&
+    typeof navigator.sendBeacon === 'function'
+  ) {
+    const blob = new Blob([body], { type: 'application/json' });
+    navigator.sendBeacon(OBS_ENDPOINT, blob);
+    return;
+  }
+
+  fetch(OBS_ENDPOINT, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body,
+    keepalive: true,
+  }).catch((error: unknown) => {
+    const normalized = normalizeError(error);
+    console.warn('[obs:send_failed]', normalized.message);
+  });
+}
+
+function send(
+  level: TelemetryLevel,
+  event: TelemetryEventName,
+  payload: TelemetryPayload = {},
+) {
+  enqueue({
+    source: 'azure-voyage-rpg-web',
+    level,
+    event,
+    timestamp: new Date().toISOString(),
+    sessionId,
+    pathname: typeof window === 'undefined' ? '/' : window.location.pathname,
+    payload,
+  });
+}
+
+export function trackEvent(
+  event: TelemetryEventName,
+  payload: TelemetryPayload = {},
+) {
+  send('info', event, payload);
+}
+
+export function reportError(
+  event: TelemetryEventName,
+  error: unknown,
+  payload: TelemetryPayload = {},
+) {
+  const normalized = normalizeError(error);
+  send('error', event, {
+    ...payload,
+    errorName: normalized.name,
+    errorMessage: normalized.message,
+  });
+}


### PR DESCRIPTION
## Summary

### 存檔穩定性（Save Hardening）
- **版本化封包**：`persistSave` 改用 `{ version, savedAt, state }` 包裝，不再裸存 `SaveState`
- **v1 自動遷移**：偵測到舊格式自動升級並回告知玩家
- **損毀/不相容存檔自動重置**：JSON 損毀或 shape 不符時清除並回傳 notice
- **UI 顯示**：啟動時若發生遷移或重置，畫面上顯示 notice

### 前端觀測性（Telemetry P0/P1）
- **`telemetry.ts`**：typed `TelemetryEventName` union、`TELEMETRY_EVENT_SCHEMA` 事件契約（level + payloadKeys + description）
- **`RuntimeMonitor.tsx`**：全域 `window.error` / `unhandledrejection` 捕捉，掛在 layout 根層
- **`GameClient` 埋點**：`session.start`、`interact.hit/miss`、`continue`、`choice.select`、`wait.advance_time`、`travel.scene/area`（成功 + 失敗）、`new_game.confirmed`、`transition`
- 環境變數：`NEXT_PUBLIC_OBSERVABILITY_ENABLED=1` + `NEXT_PUBLIC_OBSERVABILITY_ENDPOINT`

### P1.5 事件 Schema 對照
- README 補充所有事件欄位定義與 payload key 對照表
- BigQuery / Datadog / Grafana Loki 查詢範本

### P1.6 SLO / Alert 門檻（`telemetry-slo.ts`）
5 條 typed SLO，可直接 import 至監控 SDK：
- `slo.error_rate`：error / all > 3% (5min) → P1
- `slo.error_rate_hourly`：error / all > 2% (1hr) → P2
- `slo.travel_fail_rate`：travel failed / all travel > 5% (5min) → P1
- `slo.runtime_exception_burst`：runtime.* > 10 次 (5min) → P1
- `slo.interact_hit_ratio`：interact hit < 30% (1hr) → P2

README 補 Datadog Monitor YAML + Grafana PromQL alert rules，可直接貼 Terraform / DD CLI / Grafana provisioning。

## Validation
- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm test` ✅
- `pnpm build` ✅

## Scope
僅修改 `azure-voyage-rpg/*`，`azure-voyage/*` 的未追蹤更動不在本 PR 範圍內。